### PR TITLE
Add rent boundary checking

### DIFF
--- a/src/bin/agave_compat.rs
+++ b/src/bin/agave_compat.rs
@@ -12,7 +12,13 @@ struct Cli {
 fn exec(input: &PathBuf) {
     let blob = std::fs::read(input).unwrap();
     let context = InstrContext::decode(&blob[..]).unwrap();
-    let effects = solfuzz_agave::execute_instr_proto(context).unwrap();
+    let effects = match solfuzz_agave::execute_instr_proto(context) {
+        Some(e) => e,
+        None => {
+            println!("No instruction effects returned.");
+            return;
+        }
+    };
     eprintln!("Effects: {:?}", effects);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,6 +336,17 @@ fn execute_instr(input: InstrContext) -> Option<InstrEffects> {
         }
     });
 
+    // Add checks for rent boundaries
+    let arc_rent = sysvar_cache.get_rent().unwrap();
+    let sysvar_rent = Arc::as_ref(&arc_rent);
+
+    if sysvar_rent.lamports_per_byte_year > u32::MAX.into()
+        || sysvar_rent.exemption_threshold > 999.0
+        || sysvar_rent.exemption_threshold < 0.0
+        || sysvar_rent.burn_percent > 100 {
+        return None;
+    }
+
     let mut transaction_accounts =
         Vec::<TransactionAccount>::with_capacity(input.accounts.len() + 1);
     #[allow(deprecated)]


### PR DESCRIPTION
Add boundary checks for rent properties to handle undefined behavior.