### PR TITLE
Add sol_compat_vm_syscall_execute_v1 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Only supports x86_64-unknown-linux-gnu targets.
 
 Supported APIs:
 - sol_compat_instr_execute_v1
+- sol_compat_vm_syscall_execute_v1
 
 Check and test:
 

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,8 @@ fn main() -> Result<()> {
 
     let protos = &[
         proto_base_path.join("invoke.proto"),
-        proto_base_path.join("vm.proto")];
+        proto_base_path.join("vm.proto"),
+    ];
 
     protos
         .iter()

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,9 @@ use std::io::Result;
 fn main() -> Result<()> {
     let proto_base_path = std::path::PathBuf::from("proto");
 
-    let protos = &[proto_base_path.join("invoke.proto")];
+    let protos = &[
+        proto_base_path.join("invoke.proto"),
+        proto_base_path.join("vm.proto")];
 
     protos
         .iter()

--- a/proto/vm.proto
+++ b/proto/vm.proto
@@ -1,0 +1,105 @@
+syntax = "proto3";
+
+// Copied verbatim from https://github.com/firedancer-io/solfuzz/blob/main/src/proto/vm.proto
+
+// org.solana.sealevel.v1 is the target interface
+// TODO: introduce different packages for mutator inputs
+package org.solana.sealevel.v1;
+
+import "invoke.proto";
+
+// Describes an input data region. Agave's memory mapping sets up a series of
+// memory mapped regions, which combine to make the input data region.
+message InputDataRegion {
+  // Offset from the start of the input data segment (0x400000000)
+  uint64 offset = 1;
+  // Content of the memory region
+  bytes content = 2;
+  // If the memory region is writable or not
+  bool is_writable = 3;
+}
+
+// TODO: investigate make this an overlay not a context, and let each target set up the 
+// vm context from the instruction context.
+
+// Information sufficient to allow the fuzzer to generate a fd_vm_t context for 
+// execution inside the VM (excluding the instruction context).
+//
+// TODO: this currently only includes fields necessary for executing syscalls,
+// executing sBPF code will require the rest of the fields in fd_vm_t to be set.
+message VmContext {
+    // Maximum heap size in bytes
+    uint64 heap_max = 1;
+
+    // Program read-only data
+    bytes rodata = 2;
+    // Offset of the text section from the start of the program rodata segment
+    // (0x100000000)
+    uint64 rodata_text_section_offset = 3;
+    // Length of the text section in the program rodata region, in bytes.
+    uint64 rodata_text_section_length = 4;
+
+    // The input data regions
+    repeated InputDataRegion input_data_regions = 5;
+
+    // Registers
+    uint64 r0 = 6;
+    uint64 r1 = 7;
+    uint64 r2 = 8;
+    uint64 r3 = 9;
+    uint64 r4 = 10;
+    uint64 r5 = 11;
+    uint64 r6 = 12;
+    uint64 r7 = 13;
+    uint64 r8 = 14;
+    uint64 r9 = 15;
+    uint64 r10 = 16;
+    uint64 r11 = 17;
+
+    // TODO: extend this to support the rest of the vm fields, needed for
+    // full coverage of the vm interpreter code.
+}
+
+// TODO: use structured types for syscall implementation to improve fuzz coverage
+// We should seperate out the engine protos from the target protos to make implementation
+// of the targets easier.
+
+// TODO: for CPI syscalls, consider generating effects in protobufs vs full cpi
+// execution
+
+// A single invocation of a syscall
+message SyscallInvocation {
+    // The sBPF function name of the syscall
+    bytes function_name = 1;
+}
+
+// Execution context for a VM Syscall execution.
+message SyscallContext {
+    VmContext vm_ctx = 1;
+    // TODO: InflightInstruction - contain temporary fields that live for the duration of an instructions execution, and is needed if we have overhanging context from a previous instruction
+    InstrContext instr_ctx = 2;
+    SyscallInvocation syscall_invocation = 3;
+}
+
+// The effects of executing a SyscallContext.
+message SyscallEffects {
+    // EBPF error code, if the invocation was unsuccessful
+    int64 error = 1;
+    
+    // Registers
+    uint64 r0 = 2; // Result of a successful execution
+
+    // CU's remaining
+    uint64 cu_avail = 3;
+
+    // Memory regions
+    bytes heap = 4;
+    bytes stack = 5;
+    bytes inputdata = 6;
+
+    // Current number of stack frames pushed
+    uint64 frame_count = 7;
+
+    // Syscall log
+    bytes log = 8;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::missing_safety_doc)]
 
+mod vm_syscalls;
+
 use lazy_static::lazy_static;
 use prost::Message;
 use solana_program_runtime::compute_budget::ComputeBudget;

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -1,0 +1,213 @@
+use crate::{
+    load_builtins,
+    proto::{SyscallContext, SyscallEffects},
+    InstrContext,
+};
+use prost::Message;
+use solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1;
+use solana_program_runtime::solana_rbpf::vm::ContextObject;
+use solana_program_runtime::sysvar_cache::SysvarCache;
+use solana_program_runtime::{
+    compute_budget::ComputeBudget,
+    invoke_context::InvokeContext,
+    loaded_programs::LoadedProgramsForTxBatch,
+    solana_rbpf::{
+        ebpf::{self, MM_INPUT_START},
+        error::EbpfError,
+        memory_region::{MemoryMapping, MemoryRegion},
+        program::{BuiltinProgram, SBPFVersion},
+        vm::{Config, EbpfVm},
+    },
+};
+use solana_sdk::transaction_context::{TransactionAccount, TransactionContext};
+use solana_sdk::{account::AccountSharedData, rent::Rent};
+use std::{ffi::c_int, sync::Arc};
+
+const STACK_SIZE: usize = 524288; // FD_VM_STACK_MAX
+
+#[no_mangle]
+pub unsafe extern "C" fn sol_compat_vm_syscall_execute_v1(
+    out_ptr: *mut u8,
+    out_psz: *mut u64,
+    in_ptr: *mut u8,
+    in_sz: u64,
+) -> c_int {
+    let in_slice = std::slice::from_raw_parts(in_ptr, in_sz as usize);
+    let syscall_context = match SyscallContext::decode(in_slice) {
+        Ok(context) => context,
+        Err(_) => return 0,
+    };
+
+    let syscall_effects = match execute_vm_syscall(syscall_context) {
+        Some(v) => v,
+        None => return 0,
+    };
+    let out_slice = std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize);
+    let out_vec = syscall_effects.encode_to_vec();
+    if out_vec.len() > out_slice.len() {
+        return 0;
+    }
+    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
+    *out_psz = out_vec.len() as u64;
+
+    1
+}
+
+fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
+    let instr_ctx: InstrContext = input.instr_ctx?.try_into().ok()?;
+
+    // Create invoke context
+    // TODO: factor this into common code with lib.rs
+    let mut transaction_accounts =
+        Vec::<TransactionAccount>::with_capacity(instr_ctx.accounts.len() + 1);
+    #[allow(deprecated)]
+    instr_ctx
+        .accounts
+        .clone()
+        .into_iter()
+        .map(|(pubkey, account)| (pubkey, AccountSharedData::from(account)))
+        .for_each(|x| transaction_accounts.push(x));
+
+    let compute_budget = ComputeBudget {
+        compute_unit_limit: instr_ctx.cu_avail,
+        ..ComputeBudget::default()
+    };
+    let mut transaction_context = TransactionContext::new(
+        transaction_accounts.clone(),
+        Rent::default(),
+        compute_budget.max_invoke_stack_height,
+        compute_budget.max_instruction_trace_length,
+    );
+
+    // sigh ... What is this mess?
+    let mut programs_loaded_for_tx_batch = LoadedProgramsForTxBatch::default();
+    load_builtins(&mut programs_loaded_for_tx_batch);
+    let mut programs_modified_by_tx = LoadedProgramsForTxBatch::default();
+
+    let sysvar_cache = SysvarCache::default();
+    #[allow(deprecated)]
+    let (blockhash, lamports_per_signature) = sysvar_cache
+        .get_recent_blockhashes()
+        .ok()
+        .and_then(|x| (*x).last().cloned())
+        .map(|x| (x.blockhash, x.fee_calculator.lamports_per_signature))
+        .unwrap_or_default();
+
+    let mut invoke_context = InvokeContext::new(
+        &mut transaction_context,
+        &sysvar_cache,
+        None,
+        compute_budget,
+        &programs_loaded_for_tx_batch,
+        &mut programs_modified_by_tx,
+        Arc::new(instr_ctx.feature_set.clone()),
+        blockhash,
+        lamports_per_signature,
+    );
+
+    // TODO: support different versions
+    let sbpf_version = &SBPFVersion::V2;
+
+    // Set up memory mapping
+    let vm_ctx = input.vm_ctx.unwrap();
+    let rodata = vm_ctx.rodata;
+    let mut stack = vec![0; STACK_SIZE];
+    let heap_max = vm_ctx.heap_max;
+    let mut heap = vec![0; heap_max as usize];
+    let mut regions = vec![
+        MemoryRegion::new_readonly(&rodata, ebpf::MM_PROGRAM_START),
+        MemoryRegion::new_writable_gapped(&mut stack, ebpf::MM_STACK_START, 0),
+        MemoryRegion::new_writable(&mut heap, ebpf::MM_HEAP_START),
+    ];
+    let mut input_data_regions = vm_ctx.input_data_regions.clone();
+    for input_data_region in &mut input_data_regions {
+        if input_data_region.is_writable {
+            regions.push(MemoryRegion::new_writable(
+                input_data_region.content.as_mut_slice(),
+                MM_INPUT_START + input_data_region.offset,
+            ));
+        } else {
+            regions.push(MemoryRegion::new_readonly(
+                input_data_region.content.as_slice(),
+                MM_INPUT_START + input_data_region.offset,
+            ));
+        }
+    }
+    let config = &Config {
+        aligned_memory_mapping: true,
+        enable_sbpf_v2: true,
+        ..Config::default()
+    };
+    let memory_mapping = MemoryMapping::new(regions, config, sbpf_version).unwrap();
+
+    // Set up the vm instance
+    let loader = std::sync::Arc::new(BuiltinProgram::new_mock());
+    let mut vm = EbpfVm::new(
+        loader,
+        &SBPFVersion::V2,
+        &mut invoke_context,
+        memory_mapping,
+        STACK_SIZE,
+    );
+    vm.registers[0] = vm_ctx.r0;
+    vm.registers[1] = vm_ctx.r1;
+    vm.registers[2] = vm_ctx.r2;
+    vm.registers[3] = vm_ctx.r3;
+    vm.registers[4] = vm_ctx.r4;
+    vm.registers[5] = vm_ctx.r5;
+    vm.registers[6] = vm_ctx.r6;
+    vm.registers[7] = vm_ctx.r7;
+    vm.registers[8] = vm_ctx.r8;
+    vm.registers[9] = vm_ctx.r9;
+    vm.registers[10] = vm_ctx.r10;
+    vm.registers[11] = vm_ctx.r11;
+
+    // Actually invoke the syscall
+    let program_runtime_environment_v1 = create_program_runtime_environment_v1(
+        &instr_ctx.feature_set,
+        &ComputeBudget::default(),
+        true,
+        false,
+    )
+    .unwrap();
+
+    // Invoke the syscall
+    let (_, syscall_func) = program_runtime_environment_v1
+        .get_function_registry()
+        .lookup_by_name(&input.syscall_invocation?.function_name)?;
+    syscall_func(
+        &mut vm, vm_ctx.r1, vm_ctx.r2, vm_ctx.r3, vm_ctx.r4, vm_ctx.r5,
+    );
+
+    // Unwrap and return the effects of the syscall
+    let program_result = vm.program_result;
+    Some(SyscallEffects {
+        error: match program_result {
+            solana_program_runtime::solana_rbpf::error::StableResult::Ok(_) => 0,
+            solana_program_runtime::solana_rbpf::error::StableResult::Err(e) => unsafe {
+                let error_ptr = &e as *const EbpfError as *const u64;
+                (*error_ptr).try_into().unwrap()
+            },
+        },
+        r0: vm.registers[0],
+        cu_avail: vm.context_object_pointer.get_remaining(),
+        heap,
+        stack,
+        inputdata: input_data_regions
+            .iter()
+            .map(|region| region.content.clone())
+            .flatten()
+            .collect(),
+        frame_count: vm.call_depth,
+        log: invoke_context
+            .get_log_collector()?
+            .borrow()
+            .get_recorded_content()
+            .iter()
+            .fold(String::new(), |mut acc, s| {
+                acc.push_str(s);
+                acc
+            })
+            .into_bytes(),
+    })
+}


### PR DESCRIPTION
This PR adds an initial `sol_compat_vm_syscall_execute_v1` target. All the changes are confined to `src/vm_syscalls.rs` to minimise conflicts.