### PR TITLE
fix error code: GenericError misinterpreted as success

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ impl TryFrom<proto::InstrContext> for InstrContext {
 
 fn instr_err_to_num(error: &InstructionError) -> i32 {
     let serialized_err = bincode::serialize(error).unwrap();
-    i32::from_le_bytes((&serialized_err[0..4]).try_into().unwrap())
+    i32::from_le_bytes((&serialized_err[0..4]).try_into().unwrap()) + 1
 }
 
 pub struct InstrEffects {


### PR DESCRIPTION
InstructionError::GenericError is considered success.
Similarly, in FD, err==-1 is considered success.

This line also needs to be fixed: `effects->result = -exec_result` (drop -1)
https://github.com/firedancer-io/firedancer/blob/main/src/flamenco/runtime/tests/fd_exec_instr_test.c#L721

Firedancer PR: https://github.com/firedancer-io/firedancer/pull/1748