### PR TITLE
Don't extrapolate account data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -514,17 +514,7 @@ fn execute_instr(input: InstrContext) -> Option<InstrEffects> {
     {
         index
     } else {
-        transaction_accounts.push((
-            input.instruction.program_id,
-            AccountSharedData::from(Account {
-                lamports: 10000000,
-                data: b"Solana Program".to_vec(),
-                owner: solana_sdk::native_loader::id(),
-                executable: true,
-                rent_epoch: 0,
-            }),
-        ));
-        transaction_accounts.len() - 1
+        return None;
     };
 
     let mut transaction_context = TransactionContext::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,6 +823,8 @@ mod tests {
 
     #[test]
     fn test_system_program_exec() {
+        let native_loader_id = solana_sdk::native_loader::id().to_bytes().to_vec();
+
         // Ensure that a basic account transfer works
         let input = proto::InstrContext {
             program_id: vec![0u8; 32],
@@ -841,6 +843,14 @@ mod tests {
                     lamports: 0,
                     data: vec![],
                     executable: false,
+                    rent_epoch: 0,
+                },
+                proto::AcctState {
+                    address: vec![0u8; 32],
+                    owner: native_loader_id.clone(),
+                    lamports: 10000000,
+                    data: b"Solana Program".to_vec(),
+                    executable: true,
                     rent_epoch: 0,
                 },
             ],


### PR DESCRIPTION
We recently added failing behavior [here](https://github.com/firedancer-io/firedancer/pull/1838) within FD to reject cases where the program ID is not present in the accounts list. Additionally, we can't assume the owner of the account to be NativeLoader outside of native program tests. It's better to just reject these test cases and add extra validation in the fuzzer to not produce these cases.