### PR TITLE
Update protobuf files

### DIFF
--- a/proto/context.proto
+++ b/proto/context.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+package org.solana.sealevel.v1;
+
+import "sysvar.proto";
+
+// A set of feature flags.
+message FeatureSet {
+  // Every item in this list marks an enabled feature.  The value of
+  // each item is the first 8 bytes of the feature ID as a little-
+  // endian integer.
+  repeated fixed64 features = 1;
+}
+
+// A seed address.  This is not a PDA.
+message SeedAddress {
+  // The seed address base.  (32 bytes)
+  bytes base = 1;
+
+  // The seed path  (<= 32 bytes)
+  bytes seed = 2;
+
+  // The seed address owner.  (32 bytes)
+  bytes owner = 3;
+}
+
+// The complete state of an account excluding its public key.
+message AcctState {
+  // The account address.  (32 bytes)
+  bytes address = 1;
+
+  uint64 lamports = 2;
+
+  // Account data is limited to 10 MiB on Solana mainnet as of 2024-Feb.
+  bytes data = 3;
+
+  bool executable = 4;
+
+  // The rent epoch is deprecated on Solana mainnet as of 2024-Feb.
+  // If ommitted, implies a value of UINT64_MAX.
+  uint64 rent_epoch = 5;
+
+  // Address of the program that owns this account.  (32 bytes)
+  bytes owner = 6;
+
+  // The account address, but derived as a seed address.  Overrides
+  // `address` if present.
+  // TODO: This is a solfuzz specific extension and is not compliant
+  // with the org.solana.sealevel.v1 API.
+  SeedAddress seed_addr = 7;
+}
+
+// EpochContext includes context scoped to an epoch.
+// On "real" ledgers, it is created during the epoch boundary.
+message EpochContext {
+  FeatureSet features = 1;
+}
+
+
+// SlotContext includes context scoped to a block.
+// On "real" ledgers, it is created during the slot boundary.
+message SlotContext {
+  repeated bytes recent_block_hashes = 1;
+  // public key for the leader
+  bytes leader = 2;
+  // Slot number
+  fixed64 slot = 3;
+  SysvarCache sysvar_cache = 4;
+}

--- a/proto/elf.proto
+++ b/proto/elf.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package org.solana.sealevel.v1;
-import "invoke.proto";
+import "context.proto";
 
 message ELFBinary {
     bytes data = 1;

--- a/proto/invoke.proto
+++ b/proto/invoke.proto
@@ -1,45 +1,8 @@
 syntax = "proto3";
 package org.solana.sealevel.v1;
 
-// A set of feature flags.
-message FeatureSet {
-  // Every item in this list marks an enabled feature.  The value of
-  // each item is the first 8 bytes of the feature ID as a little-
-  // endian integer.
-  repeated fixed64 features = 1;
-}
-
-// The complete state of an account excluding its public key.
-message AcctState {
-  // The account address.  (32 bytes)
-  bytes address = 1;
-
-  uint64 lamports = 2;
-
-  // Account data is limited to 10 MiB on Solana mainnet as of 2024-Feb.
-  bytes data = 3;
-
-  bool executable = 4;
-
-  // The rent epoch is deprecated on Solana mainnet as of 2024-Feb.
-  // If ommitted, implies a value of UINT64_MAX.
-  uint64 rent_epoch = 5;
-
-  // Address of the program that owns this account.  (32 bytes)
-  bytes owner = 6;
-}
-
-// EpochContext includes context scoped to an epoch.
-// On "real" ledgers, it is created during the epoch boundary.
-message EpochContext {
-  FeatureSet features = 1;
-}
-
-// SlotContext includes context scoped to a block.
-// On "real" ledgers, it is created during the slot boundary.
-message SlotContext {}
-
-message TxnContext {}
+import "context.proto";
+import "txn.proto";
 
 message InstrAcct {
   // Selects an account in an external list
@@ -90,6 +53,9 @@ message InstrEffects {
   repeated AcctState modified_accounts = 3;
 
   uint64 cu_avail = 4;
+
+  // Instruction return data.
+  bytes return_data = 5;
 }
 
 // An instruction processing test fixture.

--- a/proto/sysvar.proto
+++ b/proto/sysvar.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+package org.solana.sealevel.v1;
+
+// The clock account data
+message Clock {
+  uint64 slot = 1;
+  uint64 epoch_start_timestamp = 2;
+  uint64 epoch = 3;
+  uint64 leader_schedule_epoch = 4;
+  uint64 unix_timestamp = 5;
+}
+
+// The data for the Rent account
+message Rent {
+  uint64 lamports_per_byte_year = 1;
+  double exemption_threshold = 2;
+  uint64 burn_percent = 3;
+}
+
+// The recent slot hash vector contents
+message SlotHash {
+  uint64 slot = 1;
+  bytes hash = 2;
+}
+
+// The sysvar cache for a transaction execution
+message SysvarCache {
+  Clock clock = 1;
+  Rent rent = 2;
+  // Slot hashes sysvar: SysvarS1otHashes111111111111111111111111111
+  repeated SlotHash slot_hash = 3;
+}

--- a/proto/txn.proto
+++ b/proto/txn.proto
@@ -1,0 +1,115 @@
+syntax = "proto3";
+package org.solana.sealevel.v1;
+
+import "context.proto";
+
+// Message header contains the counts of required readonly and signatures
+message MessageHeader {
+  uint32 num_required_signatures = 1;
+  uint32 num_readonly_signed_accounts = 2;
+  uint32 num_readonly_unsigned_accounts = 3;
+}
+
+
+// The instruction a transaction executes
+message CompiledInstruction {
+  // Index into the message pubkey array
+  uint32 program_id_index = 1;
+  // Indexes into the message pubkey array
+  repeated uint32 accounts = 2;
+  bytes data = 3;
+}
+
+// List of address table lookups used to load additional accounts for a transaction
+message MessageAddressTableLookup {
+  bytes account_key = 1;
+  repeated uint32 writable_indexes = 2;
+  repeated uint32 readonly_indexes = 3;
+}
+
+// Addresses loaded with on-chain lookup tables
+message LoadedAddresses {
+  repeated bytes writable = 1;
+  repeated bytes readonly = 2;
+}
+
+// Message contains the transaction data
+message TransactionMessage {
+  // Whether this is a legacy message or not
+  bool is_legacy = 1;
+
+  MessageHeader header = 2;
+  // Vector of pubkeys
+  repeated bytes account_keys = 3;
+  // Data associated with the accounts referred above. Not all accounts need to be here.
+  repeated AcctState account_shared_data = 4;
+  // The block hash contains 32-bytes
+  bytes recent_blockhash = 5;
+  // The instructions this transaction executes
+  repeated CompiledInstruction instructions = 6;
+
+  // Not available in legacy message
+  repeated MessageAddressTableLookup address_table_lookups = 7;
+  // Not available in legacy messages
+  LoadedAddresses loaded_addresses = 8;
+}
+
+// A valid verified transaction
+message SanitizedTransaction {
+  // The transaction information
+  TransactionMessage message = 1;
+  // The message hash
+  bytes message_hash = 2;
+  // Is this a voting transaction?
+  bool is_simple_vote_tx = 3;
+  // The signatures needed in the transaction
+  repeated bytes signatures = 4;
+}
+
+// This Transaction context be used to fuzz either `load_execute_and_commit_transactions`,
+// `load_and_execute_transactions` in `bank.rs` or `load_and_execute_sanitized_transactions`
+// in `svm/transaction_processor.rs`
+message TxnContext {
+  // The transaction data
+  SanitizedTransaction tx = 1;
+  // The maximum age allowed for this transaction
+  uint64 max_age = 2;
+  // The limit of bytes allowed for this transaction to load
+  optional uint64 log_messages_byte_limit = 3;
+  
+  EpochContext epoch_ctx = 4;
+  SlotContext slot_ctx = 5;
+}
+
+// The resulting state of an account after a transaction
+message ResultingState {
+  AcctState state = 1;
+  uint64 transaction_rent = 2;
+  optional RentDebits rent_debit = 3;
+}
+
+// The rent state for an account after a transaction
+message RentDebits {
+  uint64 rent_collected = 1;
+  uint64 post_balance = 2;
+}
+
+// The execution results for a transaction
+message TxnResult {
+  // Whether this transaction was executed
+  bool executed = 1;
+  // The state of each account after the transaction
+  repeated ResultingState states = 2;
+  uint64 rent = 3;
+
+  // If an executed transaction has no error
+  bool is_ok = 4;
+  // The transaction status (error code)
+  uint32 status = 5;
+  // The return data from this transaction, if any
+  bytes return_data = 6;
+  // Number of executed compute units
+  uint64 executed_units = 7;
+  // The change in accounts data len for this transaction
+  uint64 accounts_data_len_delta = 8;
+}


### PR DESCRIPTION
This PR brings newer versions of the protobuf files, so that I can write the transaction fuzzer in solfuzz-agave.

I brought them before writing the fuzzer, lest someone would rely on the old ones and cause conflicts on the code.