### PR TITLE
on_agavev2.0_push.yml: kick `solfuzz` ci

### DIFF
--- a/.github/workflows/on_agavev2.0_push.yml
+++ b/.github/workflows/on_agavev2.0_push.yml
@@ -1,4 +1,4 @@
-name: Trigger Repo B CI
+name: Trigger Solfuzz CI
 
 on:
   push:

--- a/.github/workflows/on_agavev2.0_push.yml
+++ b/.github/workflows/on_agavev2.0_push.yml
@@ -1,0 +1,19 @@
+name: Trigger Repo B CI
+
+on:
+  push:
+    branches:
+      - agave-v2.0
+jobs:
+  kick_solfuzz_ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: dispatch solfuzz CI
+        run: |
+          curl -L \
+          -X POST \
+          https://api.github.com/repos/firedancer-io/solfuzz/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          --data '{"event_type": "solfuzz_agave"}'


### PR DESCRIPTION
We want to be telling `solfuzz` that it needs to run a new ci build every time we land a PR to this repo.