### PR TITLE
Fix to prevent solfuzz panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 pub mod elf_loader;
-pub mod txn_fuzzer;
+// pub mod txn_fuzzer;
 pub mod utils;
 mod vm_syscalls;
 mod vm_validate;
@@ -561,6 +561,13 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
         }
 
         if acc.1.executable && program_cache_for_tx_batch.find(&acc.0).is_none() {
+            // load_program_with_pubkey expects the owner to be one of the bpf loader
+            if !solana_sdk::loader_v4::check_id(&acc.1.owner)
+                && !solana_sdk::bpf_loader_deprecated::check_id(&acc.1.owner)
+                && !solana_sdk::bpf_loader::check_id(&acc.1.owner)
+                && !solana_sdk::bpf_loader_upgradeable::check_id(&acc.1.owner) {
+                continue
+            }
             // https://github.com/anza-xyz/agave/blob/af6930da3a99fd0409d3accd9bbe449d82725bd6/svm/src/program_loader.rs#L124
             /* pub fn load_program_with_pubkey<CB: TransactionProcessingCallback, FG: ForkGraph>(
                 callbacks: &CB,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -565,8 +565,9 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
             if !solana_sdk::loader_v4::check_id(&acc.1.owner)
                 && !solana_sdk::bpf_loader_deprecated::check_id(&acc.1.owner)
                 && !solana_sdk::bpf_loader::check_id(&acc.1.owner)
-                && !solana_sdk::bpf_loader_upgradeable::check_id(&acc.1.owner) {
-                continue
+                && !solana_sdk::bpf_loader_upgradeable::check_id(&acc.1.owner)
+            {
+                continue;
             }
             // https://github.com/anza-xyz/agave/blob/af6930da3a99fd0409d3accd9bbe449d82725bd6/svm/src/program_loader.rs#L124
             /* pub fn load_program_with_pubkey<CB: TransactionProcessingCallback, FG: ForkGraph>(
@@ -882,7 +883,6 @@ mod tests {
             cu_avail: 10000u64,
             epoch_context: None,
             slot_context: None,
-            txn_context: None,
         };
         let output = execute_instr_proto(input);
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 pub mod elf_loader;
-// pub mod txn_fuzzer;
+pub mod txn_fuzzer;
 pub mod utils;
 mod vm_syscalls;
 mod vm_validate;


### PR DESCRIPTION
Related to https://github.com/anza-xyz/agave/security/advisories/GHSA-9ppm-69j5-4qjj. 

load_program_with_pubkey() expects that the ownership checks were done upstream at the Tx parsing level, which is not reflected in our harness. So as it expects only program accounts owned by one of the BPF loaders, Solfuzz can trigger an artificial panic.

This PR will unstuck the fuzzer from constantly triggering the panic.