### PR TITLE
fix heap_prefix copy

### DIFF
--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -179,7 +179,8 @@ fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     vm.registers[11] = vm_ctx.r11;
 
     if let Some(syscall_invocation) = input.syscall_invocation.clone() {
-        heap.copy_from_slice(&syscall_invocation.heap_prefix);
+        let size = syscall_invocation.heap_prefix.len().min(heap_max as usize);
+        heap[..size].copy_from_slice(&syscall_invocation.heap_prefix[..size]);
     }
 
     // Actually invoke the syscall


### PR DESCRIPTION
copy_from_slice needs matching sizes. Fix implementation to match firedancer harness.

Otherwise, we observe crashes during syscall fuzzing (example attached).

[crash-3b9033db0d8db808.zip](https://github.com/user-attachments/files/16331813/crash-3b9033db0d8db808.zip)
