### PR TITLE
handle MemoryMapping::new error

### DIFF
--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -154,7 +154,11 @@ fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         enable_sbpf_v2: true,
         ..Config::default()
     };
-    let memory_mapping = MemoryMapping::new(regions, config, sbpf_version).unwrap();
+
+    let memory_mapping = match MemoryMapping::new(regions, config, sbpf_version) {
+        Ok(mapping) => mapping,
+        Err(_) => return None,
+    };
 
     // Set up the vm instance
     let loader = std::sync::Arc::new(BuiltinProgram::new_mock());


### PR DESCRIPTION
Otherwise, syscall fuzzing crashes (example attached).

[crash-7dfd008e609a0270.zip](https://github.com/user-attachments/files/16332814/crash-7dfd008e609a0270.zip)
