### PR TITLE
Update agave commit to reflect redelegate removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,11 +2696,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -2835,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -2859,7 +2860,7 @@ dependencies = [
 [[package]]
 name = "solana-accounts-db"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -2904,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "solana-address-lookup-table-program"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2922,7 +2923,7 @@ dependencies = [
 [[package]]
 name = "solana-atomic-u64"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "parking_lot",
 ]
@@ -2930,7 +2931,7 @@ dependencies = [
 [[package]]
 name = "solana-bn254"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2944,7 +2945,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2969,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "solana-bucket-map"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bv",
  "bytemuck",
@@ -2987,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "rustc_version",
  "solana-sdk 2.1.0",
@@ -2996,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-program"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk 2.1.0",
@@ -3005,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "solana-config-program"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bincode",
  "chrono",
@@ -3020,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "solana-cost-model"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "ahash 0.8.11",
  "lazy_static",
@@ -3042,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "solana-curve25519"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -3054,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "solana-decode-error"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "num-traits",
 ]
@@ -3062,12 +3063,12 @@ dependencies = [
 [[package]]
 name = "solana-define-syscall"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 
 [[package]]
 name = "solana-fee"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "solana-sdk 2.1.0",
  "solana-svm-transaction",
@@ -3106,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "solana-inline-spl"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bytemuck",
  "solana-program 2.1.0",
@@ -3115,7 +3116,7 @@ dependencies = [
 [[package]]
 name = "solana-lattice-hash"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -3125,7 +3126,7 @@ dependencies = [
 [[package]]
 name = "solana-loader-v4-program"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "log",
  "solana-compute-budget",
@@ -3140,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "solana-log-collector"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "log",
 ]
@@ -3148,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "log",
  "solana-sdk 2.1.0",
@@ -3157,7 +3158,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -3177,7 +3178,7 @@ checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 [[package]]
 name = "solana-perf"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -3204,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "solana-poseidon"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -3265,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "solana-program"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3311,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "solana-program-memory"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "num-traits",
  "solana-define-syscall",
@@ -3320,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3349,7 +3350,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -3358,7 +3359,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "aquamarine",
  "arrayref",
@@ -3439,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "solana-sanitize"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 
 [[package]]
 name = "solana-sdk"
@@ -3496,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bincode",
  "bitflags 2.6.0",
@@ -3561,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk-macro"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bs58 0.5.1",
  "proc-macro2",
@@ -3572,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "solana-secp256k1-recover"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "borsh 1.5.1",
  "libsecp256k1",
@@ -3590,7 +3591,7 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 [[package]]
 name = "solana-short-vec"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "rustc_version",
  "serde",
@@ -3599,7 +3600,7 @@ dependencies = [
 [[package]]
 name = "solana-stake-program"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bincode",
  "log",
@@ -3615,7 +3616,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -3642,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-transaction"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "solana-sdk 2.1.0",
 ]
@@ -3650,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "solana-system-program"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bincode",
  "log",
@@ -3665,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "solana-timings"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -3675,7 +3676,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -3701,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "solana-type-overrides"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
@@ -3710,7 +3711,7 @@ dependencies = [
 [[package]]
 name = "solana-version"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "log",
  "rustc_version",
@@ -3724,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "solana-vote"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -3738,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bincode",
  "log",
@@ -3757,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-elgamal-proof-program"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bytemuck",
  "num-derive",
@@ -3771,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-sdk"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -3799,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-proof-program"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "bytemuck",
  "num-derive",
@@ -3813,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-sdk"
 version = "2.1.0"
-source = "git+https://github.com/anza-xyz/agave?rev=6a242355e010c628f9531955fbf5f0f9136d0c44#6a242355e010c628f9531955fbf5f0f9136d0c44"
+source = "git+https://github.com/anza-xyz/agave?rev=e964ce3fdf3ac89e097185637316d85dc95d02a6#e964ce3fdf3ac89e097185637316d85dc95d02a6"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -3873,6 +3874,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "serde",
+ "serde_json",
  "solana-accounts-db",
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,25 +16,26 @@ lazy_static = "1.4.0"
 prost = "0.13.1"
 prost-types = "0.13.1"
 libc = "0.2.155"
-solana-address-lookup-table-program = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-accounts-db = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-bpf-loader-program = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-compute-budget = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-compute-budget-program = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-config-program = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-loader-v4-program = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-log-collector = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-program = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-program-runtime = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-runtime = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44", features = ["dev-context-only-utils"] }
-solana-stake-program = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-system-program = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-svm = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-sdk = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-timings = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-vote-program = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-zk-sdk = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-zk-elgamal-proof-program = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
+serde_json = "1.0.121"
+solana-address-lookup-table-program = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-accounts-db = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-bpf-loader-program = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-compute-budget = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-compute-budget-program = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-config-program = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-loader-v4-program = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-log-collector = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-program = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-program-runtime = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-runtime = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6", features = ["dev-context-only-utils"] }
+solana-stake-program = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-system-program = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-svm = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-sdk = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-timings = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-vote-program = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-zk-sdk = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-zk-elgamal-proof-program = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
 solfuzz-agave-macro = { path = "macro" }
 thiserror = "1.0.61"
 log = "0.4.22" # without this, prost 0.11-0.13 complain
@@ -44,5 +45,5 @@ prost-build = "0.13.1"
 
 
 [patch.crates-io]
-solana-program = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
-solana-zk-token-sdk = { git = "https://github.com/anza-xyz/agave", rev = "6a242355e010c628f9531955fbf5f0f9136d0c44" }
+solana-program = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }
+solana-zk-token-sdk = { git = "https://github.com/anza-xyz/agave", rev = "e964ce3fdf3ac89e097185637316d85dc95d02a6" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,6 @@ static SUPPORTED_FEATURES: &[u64] = feature_list![
     zk_token_sdk_enabled,
     enable_partitioned_epoch_reward,
     stake_minimum_delegation_for_rewards,
-    stake_redelegate_instruction,
     skip_rent_rewrites,
     loosen_cpi_size_restriction,
     disable_turbine_fanout_experiments,


### PR DESCRIPTION
The `redelegate` stake program instruction was removed in a recent Agave commit, so we update solfuzz-agave to reflect that