### PR TITLE
Bump rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.80.1"


### PR DESCRIPTION
Rust 1.76 was released in February, so I bumped to 1.80.1, released in July.