### PR TITLE
Fix input-region loading

### DIFF
--- a/src/utils/vm/mem_regions.rs
+++ b/src/utils/vm/mem_regions.rs
@@ -36,17 +36,16 @@ pub fn setup_input_regions(
 them into InputDataRegions. The regions themselves are not copied,
 so be mindful of lifetimes. */
 pub fn extract_input_data_regions<'a>(mapping: &'a MemoryMapping<'a>) -> Vec<InputDataRegion> {
-
     match mapping {
         MemoryMapping::Aligned(mapping) => {
             // regions in AlignedMemoryMapping are sorted by vm_addr
             mapping
-            .get_regions()
-            .iter()
-            .skip_while(|region| region.vm_addr < ebpf::MM_INPUT_START)
-            .map(mem_region_to_input_data_region)
-            .collect()
-        },
+                .get_regions()
+                .iter()
+                .skip_while(|region| region.vm_addr < ebpf::MM_INPUT_START)
+                .map(mem_region_to_input_data_region)
+                .collect()
+        }
         MemoryMapping::Unaligned(mapping) => {
             // regions are in eytzinger order, so we need to collect and sort them
             let mut input_regions: Vec<InputDataRegion> = mapping
@@ -60,7 +59,7 @@ pub fn extract_input_data_regions<'a>(mapping: &'a MemoryMapping<'a>) -> Vec<Inp
             input_regions.sort_by_key(|region| region.offset);
             input_regions
         }
-        _ => vec![]
+        _ => vec![],
     }
 }
 

--- a/src/utils/vm/mem_regions.rs
+++ b/src/utils/vm/mem_regions.rs
@@ -36,21 +36,41 @@ pub fn setup_input_regions(
 them into InputDataRegions. The regions themselves are not copied,
 so be mindful of lifetimes. */
 pub fn extract_input_data_regions<'a>(mapping: &'a MemoryMapping<'a>) -> Vec<InputDataRegion> {
-    // Find first region(*) starting at MM_INPUT_START
-    // Then iterate over the regions and collect the input data regions
-    // until the end of the regions list.
-    // * Regions are sorted by vm address.
-    mapping
-        .get_regions()
-        .iter()
-        .skip_while(|region| region.vm_addr < ebpf::MM_INPUT_START)
-        .map(|region| InputDataRegion {
-            content: unsafe {
-                std::slice::from_raw_parts(region.host_addr.get() as *const u8, region.len as usize)
-                    .to_vec()
-            },
-            offset: region.vm_addr - ebpf::MM_INPUT_START,
-            is_writable: region.state.get() == MemoryState::Writable,
-        })
-        .collect()
+
+    match mapping {
+        MemoryMapping::Aligned(mapping) => {
+            // regions in AlignedMemoryMapping are sorted by vm_addr
+            mapping
+            .get_regions()
+            .iter()
+            .skip_while(|region| region.vm_addr < ebpf::MM_INPUT_START)
+            .map(mem_region_to_input_data_region)
+            .collect()
+        },
+        MemoryMapping::Unaligned(mapping) => {
+            // regions are in eytzinger order, so we need to collect and sort them
+            let mut input_regions: Vec<InputDataRegion> = mapping
+                .get_regions()
+                .iter()
+                .filter(|region| region.vm_addr >= ebpf::MM_INPUT_START)
+                .map(mem_region_to_input_data_region)
+                .collect();
+
+            // Sort the vector by `vm_addr`
+            input_regions.sort_by_key(|region| region.offset);
+            input_regions
+        }
+        _ => vec![]
+    }
+}
+
+fn mem_region_to_input_data_region(region: &MemoryRegion) -> InputDataRegion {
+    InputDataRegion {
+        content: unsafe {
+            std::slice::from_raw_parts(region.host_addr.get() as *const u8, region.len as usize)
+                .to_vec()
+        },
+        offset: region.vm_addr - ebpf::MM_INPUT_START,
+        is_writable: region.state.get() == MemoryState::Writable,
+    }
 }

--- a/src/vm_cpi_syscall.rs
+++ b/src/vm_cpi_syscall.rs
@@ -15,7 +15,7 @@ use solana_program_runtime::{
         error::StableResult,
         memory_region::{MemoryMapping, MemoryRegion},
         program::{BuiltinProgram, SBPFVersion},
-        vm::{Config, ContextObject, EbpfVm},
+        vm::{ContextObject, EbpfVm},
     },
     sysvar_cache::SysvarCache,
 };
@@ -191,13 +191,8 @@ fn execute_vm_cpi_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     let mut input_data_regions = vm_ctx.input_data_regions.clone();
     mem_regions::setup_input_regions(&mut regions, &mut input_data_regions);
 
-    let config = &Config {
-        aligned_memory_mapping: true,
-        enable_sbpf_v2: false,
-        ..Config::default()
-    };
 
-    let memory_mapping = match MemoryMapping::new(regions, config, &SBPFVersion::V1) {
+    let memory_mapping = match MemoryMapping::new(regions, program_runtime_environment_v1.get_config(), &SBPFVersion::V1) {
         Ok(mapping) => mapping,
         Err(_) => return None,
     };

--- a/src/vm_cpi_syscall.rs
+++ b/src/vm_cpi_syscall.rs
@@ -191,8 +191,11 @@ fn execute_vm_cpi_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     let mut input_data_regions = vm_ctx.input_data_regions.clone();
     mem_regions::setup_input_regions(&mut regions, &mut input_data_regions);
 
-
-    let memory_mapping = match MemoryMapping::new(regions, program_runtime_environment_v1.get_config(), &SBPFVersion::V1) {
+    let memory_mapping = match MemoryMapping::new(
+        regions,
+        program_runtime_environment_v1.get_config(),
+        &SBPFVersion::V1,
+    ) {
         Ok(mapping) => mapping,
         Err(_) => return None,
     };

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -65,8 +65,8 @@ fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     let feature_set = instr_ctx.feature_set;
 
     let program_runtime_environment_v1 =
-    create_program_runtime_environment_v1(&feature_set, &ComputeBudget::default(), true, false)
-        .unwrap();
+        create_program_runtime_environment_v1(&feature_set, &ComputeBudget::default(), true, false)
+            .unwrap();
 
     // Create invoke context
     // TODO: factor this into common code with lib.rs
@@ -138,7 +138,11 @@ fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     let mut input_data_regions = vm_ctx.input_data_regions.clone();
     mem_regions::setup_input_regions(&mut regions, &mut input_data_regions);
 
-    let memory_mapping = match MemoryMapping::new(regions, program_runtime_environment_v1.get_config(), sbpf_version) {
+    let memory_mapping = match MemoryMapping::new(
+        regions,
+        program_runtime_environment_v1.get_config(),
+        sbpf_version,
+    ) {
         Ok(mapping) => mapping,
         Err(_) => return None,
     };
@@ -171,7 +175,6 @@ fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     }
 
     // Actually invoke the syscall
-
 
     // Invoke the syscall
     let (_, syscall_func) = program_runtime_environment_v1

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -20,7 +20,7 @@ use solana_program_runtime::{
         error::StableResult,
         memory_region::{MemoryMapping, MemoryRegion},
         program::{BuiltinProgram, SBPFVersion},
-        vm::{Config, EbpfVm},
+        vm::EbpfVm,
     },
 };
 use solana_sdk::transaction_context::{TransactionAccount, TransactionContext};
@@ -63,6 +63,10 @@ fn copy_memory_prefix(dst: &mut [u8], src: &[u8]) {
 fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     let instr_ctx: InstrContext = input.instr_ctx?.try_into().ok()?;
     let feature_set = instr_ctx.feature_set;
+
+    let program_runtime_environment_v1 =
+    create_program_runtime_environment_v1(&feature_set, &ComputeBudget::default(), true, false)
+        .unwrap();
 
     // Create invoke context
     // TODO: factor this into common code with lib.rs
@@ -134,13 +138,7 @@ fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     let mut input_data_regions = vm_ctx.input_data_regions.clone();
     mem_regions::setup_input_regions(&mut regions, &mut input_data_regions);
 
-    let config = &Config {
-        aligned_memory_mapping: true,
-        enable_sbpf_v2: true,
-        ..Config::default()
-    };
-
-    let memory_mapping = match MemoryMapping::new(regions, config, sbpf_version) {
+    let memory_mapping = match MemoryMapping::new(regions, program_runtime_environment_v1.get_config(), sbpf_version) {
         Ok(mapping) => mapping,
         Err(_) => return None,
     };
@@ -173,9 +171,7 @@ fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     }
 
     // Actually invoke the syscall
-    let program_runtime_environment_v1 =
-        create_program_runtime_environment_v1(&feature_set, &ComputeBudget::default(), true, false)
-            .unwrap();
+
 
     // Invoke the syscall
     let (_, syscall_func) = program_runtime_environment_v1


### PR DESCRIPTION
Current method of loading regions hardcodes the use of `AlignedMemoryMapping`, which does not work with direct mapping. Instead of hardcoding the `Config` object passed to the MemoryMapping function, we can instead use the config generated in `create_program_runtime_v1`. This way, the correct options are set depending on whether direct mapping is enabled, which in turn determine which MemoryMapping variant to use. 

Furthermore, `UnalignedMemoryMapping` orders the regions differently from AlignedMM, so we need to handle that differently when extracting the regions into our effects.