### PR TITLE
CRIT: placeholder error kind in syscall effects

### DIFF
--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -248,6 +248,7 @@ fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         rodata,
         frame_count: vm.call_depth,
         error: stable_result_to_err_no(program_result, &invoke_context, &program_id),
+        error_kind: 0, // FIXME: placeholder
         log: invoke_context
             .get_log_collector()?
             .borrow()


### PR DESCRIPTION
Placeholder for error_kind field in SyscallEffects while this [PR](https://github.com/firedancer-io/solfuzz-agave/pull/120) is a WIP