### PR TITLE
Remove v4 loader from supported features list

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ static SUPPORTED_FEATURES: &[u64] = feature_list![
     enable_poseidon_syscall,
     timely_vote_credits,
     remaining_compute_units_syscall_enabled,
-    enable_program_runtime_v2_and_loader_v4,
+    // enable_program_runtime_v2_and_loader_v4,
     better_error_codes_for_tx_lamport_check,
     enable_alt_bn128_compression_syscall,
     update_hashes_per_tick2,


### PR DESCRIPTION
v4 loader feature has not been properly implemented in FD yet, so any mismatches caused by the fuzzer choosing to enable this feature are not accurate.