### PR TITLE
update macro to use new cache entry type

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -51,13 +51,18 @@ pub fn load_core_bpf_program(_: TokenStream) -> TokenStream {
         let elf_data = read_file(Path::new(&elf_path));
         let elf_bytes = ElfBytes(elf_data);
 
+        println!(
+            "    [SF_AGAVE]: Overriding builtin program with provided BPF target: {}",
+            &program_id
+        );
+
         return quote! {
             let program_id = Pubkey::new_from_array(#program_id_bytes);
             let elf = #elf_bytes;
             cache.replenish(
                 program_id,
                 Arc::new(
-                    solana_program_runtime::loaded_programs::LoadedProgram::new(
+                    solana_program_runtime::loaded_programs::ProgramCacheEntry::new(
                         &solana_sdk::bpf_loader_upgradeable::id(),
                         cache.environments.program_runtime_v1.clone(),
                         0,


### PR DESCRIPTION
#### Problem
The `load_core_bpf_program!` macro adds a provided BPF program to the program cache in place of a builtin. The type name for a cache entry has since changed from `LoadedProgram` to `ProgramCacheEntry`.

#### Summary of Changes
Update the type name, and also add a log so developers know they've successfully overridden a builtin during compilation.