### PR TITLE
update `fetch_programs.sh` script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/programs
+/bpf_programs
+/protosol
 /target*
 test/self_test
 .vscode/

--- a/scripts/fetch_program.sh
+++ b/scripts/fetch_program.sh
@@ -5,14 +5,20 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-mkdir -p programs
+BPF_PROGRAMS_DIR="bpf_programs"
+BPF_PROGRAMS_OUT_DIR="$BPF_PROGRAMS_DIR/lib"
 
-if [ -d "programs/$1" ]; then
+mkdir -p $BPF_PROGRAMS_DIR
+mkdir -p $BPF_PROGRAMS_OUT_DIR
+
+if [ -d "$BPF_PROGRAMS_DIR/$1" ]; then
     echo "Updating program $1...";
-    (cd programs/$1 && git fetch && git pull);
+    (cd $BPF_PROGRAMS_DIR/$1 && git fetch && git pull);
 else
     echo "Cloning program $1...";
-    git clone https://github.com/solana-program/$1 programs/$1;
+    git clone https://github.com/solana-program/$1 $BPF_PROGRAMS_DIR/$1;
 fi
 
-cargo build-sbf --manifest-path=programs/$1/program/Cargo.toml --sbf-out-dir programs
+cargo build-sbf --manifest-path=$BPF_PROGRAMS_DIR/$1/program/Cargo.toml \
+    --features bpf-entrypoint \
+    --sbf-out-dir $BPF_PROGRAMS_OUT_DIR


### PR DESCRIPTION
#### Problem
The `fetch_script.sh` script doesn't build the BPF program binary with `--features bpf-entrypoint`, however, all of the BPF versions of builtins follow the same pattern, which makes the BPF entrypoint an opt-in feature on the crate.

#### Summary of Changes
Add the `--features bpf-entrypoint` flag to the build command. Also updates the directory names to be more clear.