### PR TITLE
configure cache environment before loading builtins

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -638,15 +638,6 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
     // sigh ... What is this mess?
     let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
     program_cache_for_tx_batch.set_slot_for_tests(clock.slot);
-    let loaded_builtins = load_builtins(&mut program_cache_for_tx_batch);
-
-    // Skip if the program account is a native program and is not owned by the native loader
-    // (Would call the owner instead)
-    if loaded_builtins.contains(&transaction_accounts[program_idx].0)
-        && transaction_accounts[program_idx].1.owner() != &solana_sdk::native_loader::id()
-    {
-        return None;
-    }
 
     let program_runtime_environment_v1 =
         solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1(
@@ -662,6 +653,16 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
     };
     program_cache_for_tx_batch.environments = environments.clone();
     program_cache_for_tx_batch.upcoming_environments = Some(environments.clone());
+
+    let loaded_builtins = load_builtins(&mut program_cache_for_tx_batch);
+
+    // Skip if the program account is a native program and is not owned by the native loader
+    // (Would call the owner instead)
+    if loaded_builtins.contains(&transaction_accounts[program_idx].0)
+        && transaction_accounts[program_idx].1.owner() != &solana_sdk::native_loader::id()
+    {
+        return None;
+    }
 
     #[allow(deprecated)]
     let (blockhash, lamports_per_signature) = sysvar_cache


### PR DESCRIPTION
#### Problem
The steps which configure the loader (syscalls) on the program cache (`environments.program_runtime_v1`, etc.) occur after the call to `load_builtins`. Since the step to override a builtin with a BPF program also occurs during `load_builtins`, the syscalls should be registered before adding the programs.

#### Summary of Changes
Simply move the call to `load_builtins` below the loader configuration step.