### PR TITLE
make macro remove builtin ID from hash set

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -52,10 +52,13 @@ pub fn load_core_bpf_program(_: TokenStream) -> TokenStream {
         let elf_bytes = ElfBytes(elf_data);
 
         return quote! {
-            let program_id = Pubkey::new_from_array(#program_id_bytes);
+            // Load the program ID and ELF from environment inputs.
+            let target_program_id = Pubkey::new_from_array(#program_id_bytes);
             let elf = #elf_bytes;
+
+            // Replace the builtin in the cache with the loaded ELF.
             cache.replenish(
-                program_id,
+                target_program_id,
                 Arc::new(
                     solana_program_runtime::loaded_programs::LoadedProgram::new(
                         &solana_sdk::bpf_loader_upgradeable::id(),
@@ -69,6 +72,9 @@ pub fn load_core_bpf_program(_: TokenStream) -> TokenStream {
                     .unwrap(),
                 ),
             );
+
+            // Remove the builtin ID from the `builtins` hash set.
+            builtins.remove(&target_program_id);
         }
         .into();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,11 +540,6 @@ fn load_builtins(cache: &mut ProgramCacheForTxBatch) -> HashSet<Pubkey> {
         )),
     );
 
-    // Will overwrite a builtin if environment variable `CORE_BPF_PROGRAM_ID`
-    // is set to a valid program id.
-    load_core_bpf_program!();
-
-    // Return builtins as a HashSet
     let mut builtins: HashSet<Pubkey> = HashSet::new();
     builtins.insert(solana_sdk::address_lookup_table::program::id());
     builtins.insert(solana_sdk::bpf_loader_deprecated::id());
@@ -556,6 +551,13 @@ fn load_builtins(cache: &mut ProgramCacheForTxBatch) -> HashSet<Pubkey> {
     builtins.insert(solana_system_program::id());
     builtins.insert(solana_vote_program::id());
     builtins.insert(solana_zk_sdk::zk_elgamal_proof_program::id());
+
+    // If the `CORE_BPF_PROGRAM_ID` and `CORE_BPF_TARGET` environment variables
+    // are set, this macro will do the following:
+    // * Replace the designated builtin program in the cache with a loaded ELF.
+    // * Remove that builtin's program ID from the `builtins` set above.
+    load_core_bpf_program!();
+
     builtins
 }
 


### PR DESCRIPTION
#### Problem
The `load_builtins` function returns a hash set of all of the builtin program IDs added to the cache. This value is later checked for any programs that are not owned by the native loader.

The check for builtins not owned by the native loader could be placed behind a feature flag, however, to avoid any confusion for other contributors who may use the `loaded_builtins` variable for other checks, the hash set should instead always reflect the list of actual builtins.

#### Summary of Changes
Adjust the `load_core_bpf_program!` macro to remove the overridden program from the set of builtin IDs, ensuring the resulting `HashSet<Pubkey>` is accurate.