### PR TITLE
update build script with force-recompile flag

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,16 @@
 use std::io::Result;
 
 fn main() -> Result<()> {
+    // Tells rustc to recompile the `load_core_bpf_program!` macro if either
+    // of the required environment variables has changed.
     println!("cargo:rerun-if-env-changed=CORE_BPF_PROGRAM_ID");
     println!("cargo:rerun-if-env-changed=CORE_BPF_TARGET");
+    // Sometimes, the environment variables may be exactly the same, but the
+    // program binary itself may have changed. One can provide a
+    // `FORCE_RECOMPILE=true` to force the macro to re-compile.
+    if std::env::var("FORCE_RECOMPILE").as_deref() == Ok("true") {
+        println!("cargo:rerun-if-changed=force_rebuild");
+    }
 
     let proto_base_path = std::path::PathBuf::from("protosol/proto");
 


### PR DESCRIPTION
#### Problem
The build script is already configured to detect changes to either environment variable `CORE_BPF_PROGRAM_ID` or `CORE_BPF_TARGET`. However, sometimes the variables may not have changed, but the target binary may have (imagine a case where you made changes to a program and have now recompiled it).

#### Summary of Changes
Configure the build script to allow the presence of a `FORCE_RECOMPILE` variable, which does as it says, forces the build script to recompile the `load_core_bpf_program!` macro.

This way, you can set the environment variables `CORE_BPF_PROGRAM_ID` and `CORE_BPF_TARGET`, and then after rebuilding your program you can pass `FORCE_RECOMPILE=true` to build a SolFuzz-Agave target with a recompiled `load_core_bpf_program!` macro, thus including the updated ELF.