### PR TITLE
stub program account patch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,7 +661,7 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
             // Note: Agave does this during transaction account loading.
             // https://github.com/anza-xyz/agave/blob/6d74d13749829d463fabccebd8203edf0cf4c500/svm/src/account_loader.rs#L246-L249
             if *pubkey == input.instruction.program_id {
-                let mut stubbed_out_program_account = AccountSharedData::default();
+                let mut stubbed_out_program_account: AccountSharedData = account.clone().into();
                 stubbed_out_program_account.set_owner(solana_sdk::bpf_loader_upgradeable::id());
                 stubbed_out_program_account.set_executable(true);
                 return (*pubkey, stubbed_out_program_account);


### PR DESCRIPTION
Updates the stubbing of program accounts under the `core-bpf` feature to use the rest of the account's state, rather than creating a new `AccountSharedData`.