### PR TITLE
core-bpf: feature-flag conformance special-casing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,5 +55,8 @@ solana-zk-token-sdk = { git = "https://github.com/firedancer-io/agave", rev = "6
 # This feature is used to compile a target with a builtin replaced by a BPF program.
 # Requires the `CORE_BPF_PROGRAM_ID` and `CORE_BPF_TARGET` environment variables.
 core-bpf = []
+# Same as the `core-bpf` feature, but also includes special-casing required for
+# conformance testing a BPF program against a builtin.
+core-bpf-conformance = []
 # This feature is used to stub out certain parts of the agave runtime for fuzzing
 stub-agave = ["solana-program-runtime/stub-proc-instr"]

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -106,17 +106,17 @@ pub fn declare_core_bpf_default_compute_units(_: TokenStream) -> TokenStream {
 
         if program_id == solana_sdk::address_lookup_table::program::id() {
             tokens = quote! {
-                #[cfg(feature = "core-bpf")]
+                #[cfg(feature = "core-bpf-conformance")]
                 const CORE_BPF_DEFAULT_COMPUTE_UNITS: u64 = solana_address_lookup_table_program::processor::DEFAULT_COMPUTE_UNITS;
             }
         } else if program_id == solana_sdk::config::program::id() {
             tokens = quote! {
-                #[cfg(feature = "core-bpf")]
+                #[cfg(feature = "core-bpf-conformance")]
                 const CORE_BPF_DEFAULT_COMPUTE_UNITS: u64 = solana_config_program::config_processor::DEFAULT_COMPUTE_UNITS;
             }
         } else if program_id == solana_sdk::stake::program::id() {
             tokens = quote! {
-                #[cfg(feature = "core-bpf")]
+                #[cfg(feature = "core-bpf-conformance")]
                 const CORE_BPF_DEFAULT_COMPUTE_UNITS: u64 = solana_stake_program::stake_instruction::DEFAULT_COMPUTE_UNITS;
             }
         }

--- a/scripts/build_core_bpf.sh
+++ b/scripts/build_core_bpf.sh
@@ -33,6 +33,6 @@ set_core_bpf_vars "$1"
 
 CORE_BPF_PROGRAM_ID=$CORE_BPF_PROGRAM_ID CORE_BPF_TARGET=$CORE_BPF_TARGET FORCE_RECOMPILE=true $CARGO build \
     --target x86_64-unknown-linux-gnu \
-    --features core-bpf \
+    --features core-bpf-conformance \
     --lib \
     --release


### PR DESCRIPTION
First, this change simply renames the `core-bpf` feature flag to `core-bpf-conformance`, which includes all of the special-casing I've added to the harness for testing BPF vs. builtin.

Secondly, it adds a feature `core-bpf`, which _only_ does the adding of the ELF, and no special-casing. This is useful for testing just a BPF program without comparing it against a builtin, for example with custom fixtures such as the ones in here: https://github.com/solana-program/config/pull/29