### PR TITLE
remove zk_token_sdk_enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,7 +200,6 @@ static SUPPORTED_FEATURES: &[u64] = feature_list![
     pico_inflation,
     warp_timestamp_again,
     blake3_syscall_enabled,
-    zk_token_sdk_enabled,
     curve25519_syscall_enabled,
     enable_partitioned_epoch_reward,
     stake_raise_minimum_delegation_to_1_sol,


### PR DESCRIPTION
ZkTokenProof1111111111111111111111111111111 is deprecated and will never be activated
