### PR TITLE
core-bpf: fix builtins list removal step

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -79,9 +79,6 @@ pub fn load_core_bpf_program(_: TokenStream) -> TokenStream {
                     .unwrap(),
                 ),
             );
-
-            // Remove the builtin ID from the `builtins` hash set.
-            builtins.remove(&target_program_id);
         }
         .into();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,9 +559,8 @@ fn load_builtins(cache: &mut ProgramCacheForTxBatch, feature_set: &FeatureSet) {
     }
 
     // If the `CORE_BPF_PROGRAM_ID` and `CORE_BPF_TARGET` environment variables
-    // are set, this macro will do the following:
-    // * Replace the designated builtin program in the cache with a loaded ELF.
-    // * Remove that builtin's program ID from the `builtins` set above.
+    // are set, this macro will replace the designated builtin program in the
+    // cache with a loaded ELF.
     load_core_bpf_program!();
 }
 


### PR DESCRIPTION
The `builtins` hash set was removed in a previous commit, but the macro wasn't updated.

This change updates the macro so it doesn't generate code that tries to remove a builtin from the hash set, since it doesn't exist anymore!