### PR TITLE
Revert "Fix CoW region handling for cpi/syscall/vm harnesses (#209)"

### DIFF
--- a/src/utils/vm/mem_regions.rs
+++ b/src/utils/vm/mem_regions.rs
@@ -48,9 +48,6 @@ fn mem_region_to_input_data_region(region: &MemoryRegion) -> InputDataRegion {
                 .to_vec()
         },
         offset: region.vm_addr - ebpf::MM_INPUT_START,
-        is_writable: matches!(
-            region.state.get(),
-            MemoryState::Writable | MemoryState::Cow(_)
-        ),
+        is_writable: region.state.get() == MemoryState::Writable,
     }
 }

--- a/src/vm_cpi_syscall.rs
+++ b/src/vm_cpi_syscall.rs
@@ -29,7 +29,6 @@ use solana_program_runtime::{
 };
 use solana_sdk::{
     account::{AccountSharedData, WritableAccount},
-    entrypoint::MAX_PERMITTED_DATA_INCREASE,
     instruction::InstructionError,
     pubkey::Pubkey,
     rent::Rent,
@@ -37,7 +36,7 @@ use solana_sdk::{
         IndexOfAccount, InstructionAccount, TransactionAccount, TransactionContext,
     },
 };
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::{cell::RefCell, sync::Arc};
 
 #[cfg(feature = "stub-agave")]
 use {prost::Message, std::ffi::c_int};
@@ -267,21 +266,7 @@ pub fn execute_vm_cpi_syscall(input: SyscallContext) -> Option<SyscallEffects> {
 
     let sbpf_version = SBPFVersion::V0;
 
-    let cow_cb_accounts = Rc::clone(invoke_context.borrow_mut().transaction_context.accounts());
-    let cow_cb = Box::new(move |index_in_transaction| {
-        let mut account = cow_cb_accounts
-            .try_borrow_mut(index_in_transaction as IndexOfAccount)
-            .map_err(|_| ())?;
-        cow_cb_accounts
-            .touch(index_in_transaction as IndexOfAccount)
-            .map_err(|_| ())?;
-
-        if account.is_shared() {
-            account.reserve(MAX_PERMITTED_DATA_INCREASE);
-        }
-        Ok(account.data_as_mut_slice().as_mut_ptr() as u64)
-    });
-    let memory_mapping = match MemoryMapping::new_with_cow(regions, cow_cb, config, sbpf_version) {
+    let memory_mapping = match MemoryMapping::new(regions, config, sbpf_version) {
         Ok(mapping) => mapping,
         Err(_) => return None,
     };

--- a/src/vm_interp.rs
+++ b/src/vm_interp.rs
@@ -32,12 +32,10 @@ use solana_program_runtime::{
 use solana_program_test::IndexOfAccount;
 use solana_rent::Rent;
 use solana_sdk::{
-    account::WritableAccount,
-    entrypoint::MAX_PERMITTED_DATA_INCREASE,
     feature_set::bpf_account_data_direct_mapping,
     transaction_context::{TransactionAccount, TransactionContext},
 };
-use std::{borrow::Borrow, cell::RefCell, ffi::c_int, rc::Rc, sync::Arc};
+use std::{borrow::Borrow, cell::RefCell, ffi::c_int, sync::Arc};
 
 declare_builtin_function!(
     SyscallStub,
@@ -326,21 +324,7 @@ pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffec
         .chain(input_memory_regions)
         .collect();
 
-    let cow_cb_accounts = Rc::clone(invoke_context.borrow_mut().transaction_context.accounts());
-    let cow_cb = Box::new(move |index_in_transaction| {
-        let mut account = cow_cb_accounts
-            .try_borrow_mut(index_in_transaction as IndexOfAccount)
-            .map_err(|_| ())?;
-        cow_cb_accounts
-            .touch(index_in_transaction as IndexOfAccount)
-            .map_err(|_| ())?;
-
-        if account.is_shared() {
-            account.reserve(MAX_PERMITTED_DATA_INCREASE);
-        }
-        Ok(account.data_as_mut_slice().as_mut_ptr() as u64)
-    });
-    let memory_mapping = match MemoryMapping::new_with_cow(regions, cow_cb, config, sbpf_version) {
+    let memory_mapping = match MemoryMapping::new(regions, config, sbpf_version) {
         Ok(mapping) => mapping,
         Err(_) => return None,
     };

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -31,15 +31,14 @@ use solana_program_runtime::{
 };
 use solana_sdk::transaction_context::{TransactionAccount, TransactionContext};
 use solana_sdk::{
-    account::{AccountSharedData, WritableAccount},
+    account::AccountSharedData,
     clock::Clock,
-    entrypoint::MAX_PERMITTED_DATA_INCREASE,
     epoch_schedule::EpochSchedule,
     rent::Rent,
     sysvar::{last_restart_slot, SysvarId},
 };
 use solana_sdk::{pubkey::Pubkey, transaction_context::IndexOfAccount};
-use std::{cell::RefCell, ffi::c_int, rc::Rc, sync::Arc};
+use std::{cell::RefCell, ffi::c_int, sync::Arc};
 
 #[no_mangle]
 pub unsafe extern "C" fn sol_compat_vm_syscall_execute_v1(
@@ -284,21 +283,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         .chain(input_memory_regions)
         .collect();
 
-    let cow_cb_accounts = Rc::clone(invoke_context.borrow_mut().transaction_context.accounts());
-    let cow_cb = Box::new(move |index_in_transaction| {
-        let mut account = cow_cb_accounts
-            .try_borrow_mut(index_in_transaction as IndexOfAccount)
-            .map_err(|_| ())?;
-        cow_cb_accounts
-            .touch(index_in_transaction as IndexOfAccount)
-            .map_err(|_| ())?;
-
-        if account.is_shared() {
-            account.reserve(MAX_PERMITTED_DATA_INCREASE);
-        }
-        Ok(account.data_as_mut_slice().as_mut_ptr() as u64)
-    });
-    let memory_mapping = match MemoryMapping::new_with_cow(regions, cow_cb, config, sbpf_version) {
+    let memory_mapping = match MemoryMapping::new(regions, config, sbpf_version) {
         Ok(mapping) => mapping,
         Err(_) => return None,
     };


### PR DESCRIPTION
This reverts commit 94c5de66a9106c0fa33257aa305ac95b5d265115.