### PR TITLE
update program_cache_for_tx_batch logic in instr fuzzer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -796,7 +796,7 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
             return None;
         }
 
-        if acc.1.executable && program_cache_for_tx_batch.find(&acc.0).is_none() {
+        if program_cache_for_tx_batch.find(&acc.0).is_none() {
             // load_program_with_pubkey expects the owner to be one of the bpf loader
             if !solana_sdk::loader_v4::check_id(&acc.1.owner)
                 && !solana_sdk::bpf_loader_deprecated::check_id(&acc.1.owner)


### PR DESCRIPTION
in `load_and_execute_sanitized_transactions`, before `replenish_program_cache`, agave calls `filter_executable_program_accounts` which checks the owner of the account is part of `PROGRAM_OWNERS`