### PR TITLE
bpf-program-conformance: hot-swap program account

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -517,5 +517,6 @@ crate-type = ["cdylib", "rlib"]
 prost-build = "0.13.1"
 
 [features]
+bpf-program-conformance = []
 core-bpf = []
 core-bpf-conformance = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,9 +52,14 @@ use std::ffi::c_int;
 use std::sync::Arc;
 use thiserror::Error;
 
+#[cfg(any(
+    feature = "bpf-program-conformance",
+    feature = "core-bpf",
+    feature = "core-bpf-conformance",
+))]
+use solana_sdk::account::WritableAccount;
 #[cfg(any(feature = "core-bpf", feature = "core-bpf-conformance"))]
 use solana_sdk::{
-    account::WritableAccount,
     slot_hashes::{SlotHash, SlotHashes},
     sysvar::Sysvar,
 };
@@ -743,7 +748,11 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
         .accounts
         .iter()
         .map(|(pubkey, account)| {
-            #[cfg(any(feature = "core-bpf", feature = "core-bpf-conformance"))]
+            #[cfg(any(
+                feature = "bpf-program-conformance",
+                feature = "core-bpf",
+                feature = "core-bpf-conformance",
+            ))]
             // Fixtures provide the program account as a builtin (owned by
             // native loader), but the program-runtime will expect the account
             // owner to match the cache entry.
@@ -817,7 +826,11 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
     let mut newly_loaded_programs = HashSet::<Pubkey>::new();
 
     for acc in &input.accounts {
-        #[cfg(any(feature = "core-bpf", feature = "core-bpf-conformance"))]
+        #[cfg(any(
+            feature = "bpf-program-conformance",
+            feature = "core-bpf",
+            feature = "core-bpf-conformance",
+        ))]
         // The Core BPF program's ELF has already been added to the cache.
         // Its transaction account was stubbed out, so it can't be loaded via
         // callback (inputs), since the account doesn't contain the ELF.


### PR DESCRIPTION
Just like with the Core BPF conformance testing, if the program account is owned by the wrong loader, the VM serialization can sometimes blow up, especially if the loader is v1 when the input region was serialized as a v2 or v3 program.

It's worth noting that the situation this hot-swap prevents is actually impossible on all clusters. If SPL-Token is under loader v2, there's no way an account can be provided as input with the same address as SPL-Token but owned by a different loader.

So, let's make sure we hot-swap the account owner just like before.