### PR TITLE
chore: recommend fetching protobuf defs when missing

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,18 @@ fn main() -> Result<()> {
         .iter()
         .for_each(|proto| println!("cargo:rerun-if-changed={}", proto.display()));
 
+    for proto in protos {
+        if !proto.exists() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!(
+                    "Proto file does not exist: {}. Run ./scripts/fetch_proto.sh",
+                    proto.display()
+                ),
+            ));
+        }
+    }
+
     prost_build::compile_protos(protos, &[proto_base_path])?;
 
     Ok(())


### PR DESCRIPTION
Before:
```
  Error: Custom { kind: Other, error: "protoc failed: Could not make proto path relative: protosol/proto/type.proto: No such file or directory\n" }
```
After:
```
  Error: Custom { kind: NotFound, error: "Proto file does not exist: protosol/proto/type.proto. Run ./scripts/fetch_proto.sh" }
  ```