### PR TITLE
syscall, vm, instruction: clean up vm / syscall harnesses and centralize common logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,16 +442,16 @@ impl TryFrom<proto::InstrContext> for InstrContext {
 }
 
 pub fn get_instr_accounts(
-    txn_accounts: &[TransactionAccount],
+    txn_context: &TransactionContext,
     acct_metas: &StableVec<AccountMeta>,
 ) -> Vec<InstructionAccount> {
     let mut instruction_accounts: Vec<InstructionAccount> =
         Vec::with_capacity(acct_metas.len().try_into().unwrap());
     for (instruction_account_index, account_meta) in acct_metas.iter().enumerate() {
-        let index_in_transaction = txn_accounts
-            .iter()
-            .position(|(key, _account)| *key == account_meta.pubkey)
-            .unwrap_or(txn_accounts.len()) as IndexOfAccount;
+        let index_in_transaction = txn_context
+            .find_index_of_account(&account_meta.pubkey)
+            .unwrap_or(txn_context.get_number_of_accounts())
+            as IndexOfAccount;
         let index_in_callee = instruction_accounts
             .get(0..instruction_account_index)
             .unwrap()
@@ -607,7 +607,16 @@ fn initialize_program_cache(cache: &mut ProgramCacheForTxBatch, feature_set: &Fe
     load_bpf_program!();
 }
 
-fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
+fn create_invoke_context_fields(
+    input: &mut InstrContext,
+) -> Option<(
+    TransactionContext,
+    SysvarCache,
+    ProgramCacheForTxBatch,
+    Hash,
+    u64,
+    ComputeBudget,
+)> {
     unsafe {
         if TOGGLE_DIRECT_MAPPING {
             {
@@ -742,6 +751,17 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
         return None;
     };
 
+    if !input
+        .accounts
+        .iter()
+        .any(|(pubkey, _)| pubkey == &input.instruction.program_id)
+    {
+        input.accounts.push((
+            input.instruction.program_id,
+            AccountSharedData::default().into(),
+        ));
+    }
+
     let mut transaction_accounts = Vec::<TransactionAccount>::with_capacity(input.accounts.len());
     #[allow(deprecated)]
     input
@@ -771,10 +791,6 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
             (*pubkey, AccountSharedData::from(account.clone()))
         })
         .for_each(|x| transaction_accounts.push(x));
-
-    let program_idx = transaction_accounts
-        .iter()
-        .position(|(pubkey, _)| *pubkey == input.instruction.program_id)?;
 
     let mut transaction_context = TransactionContext::new(
         transaction_accounts.clone(),
@@ -864,7 +880,7 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
                 reload: bool,
             ) -> Option<Arc<ProgramCacheEntry>> { */
             if let Some(loaded_program) = program_loader::load_program_with_pubkey(
-                &input,
+                input,
                 &environments,
                 &acc.0,
                 clock.slot,
@@ -876,8 +892,29 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
         }
     }
 
+    Some((
+        transaction_context,
+        sysvar_cache,
+        program_cache_for_tx_batch,
+        blockhash,
+        lamports_per_signature,
+        compute_budget,
+    ))
+}
+
+fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
     let log_collector = LogCollector::new_ref();
-    let env_config = EnvironmentConfig::new(
+
+    let (
+        mut transaction_context,
+        sysvar_cache,
+        mut program_cache_for_tx_batch,
+        blockhash,
+        lamports_per_signature,
+        compute_budget,
+    ) = create_invoke_context_fields(&mut input)?;
+
+    let environment_config = EnvironmentConfig::new(
         blockhash,
         lamports_per_signature,
         0,
@@ -885,29 +922,30 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
         Arc::new(input.feature_set.clone()),
         &sysvar_cache,
     );
-    let mut invoke_context = InvokeContext::new(
-        &mut transaction_context,
-        &mut program_cache_for_tx_batch,
-        env_config,
-        Some(log_collector.clone()),
-        compute_budget,
-    );
 
-    let program_indices = &[program_idx as u16];
+    let program_idx =
+        transaction_context.find_index_of_program_account(&input.instruction.program_id)?;
+    let program_indices = &[program_idx];
 
     let mut compute_units_consumed = 0u64;
 
-    let mut timings = ExecuteTimings::default();
-
     let instruction_accounts =
-        get_instr_accounts(&transaction_accounts, &input.instruction.accounts);
+        get_instr_accounts(&transaction_context, &input.instruction.accounts);
+
+    let mut invoke_context = InvokeContext::new(
+        &mut transaction_context,
+        &mut program_cache_for_tx_batch,
+        environment_config,
+        Some(log_collector.clone()),
+        compute_budget,
+    );
 
     let result = invoke_context.process_instruction(
         &input.instruction.data,
         &instruction_accounts,
         program_indices,
         &mut compute_units_consumed,
-        &mut timings,
+        &mut ExecuteTimings::default(),
     );
 
     #[cfg(feature = "core-bpf-conformance")]
@@ -919,8 +957,16 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
         .saturating_sub(CORE_BPF_DEFAULT_COMPUTE_UNITS);
     #[cfg(not(feature = "core-bpf-conformance"))]
     let cu_avail = input.cu_avail - compute_units_consumed;
-
     let return_data = transaction_context.get_return_data().1.to_vec();
+
+    let account_keys: Vec<Pubkey> = (0..transaction_context.get_number_of_accounts())
+        .map(|index| {
+            *transaction_context
+                .get_key_of_account_at_index(index)
+                .clone()
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
 
     Some(InstrEffects {
         custom_err: if let Err(InstructionError::Custom(code)) = result {
@@ -1010,8 +1056,8 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
             .deconstruct_without_keys()
             .unwrap()
             .into_iter()
-            .enumerate()
-            .map(|(index, data)| {
+            .zip(account_keys)
+            .map(|(account, key)| {
                 #[cfg(any(feature = "core-bpf", feature = "core-bpf-conformance"))]
                 // Fixtures provide the program account as a builtin account
                 // (owned by native loader).
@@ -1021,16 +1067,14 @@ fn execute_instr(mut input: InstrContext) -> Option<InstrEffects> {
                 //
                 // We need to swap back in the original here to avoid a
                 // mismatch.
-                if index == program_idx {
-                    if let Some(program_account) = input
-                        .accounts
-                        .iter()
-                        .find(|(pubkey, _)| *pubkey == input.instruction.program_id)
-                    {
-                        return (program_account.0, program_account.1.clone());
-                    }
+                if let Some(program_account) = input
+                    .accounts
+                    .iter()
+                    .find(|(pubkey, _)| *pubkey == input.instruction.program_id)
+                {
+                    return (program_account.0, program_account.1.clone());
                 }
-                (transaction_accounts[index].0, data.into())
+                (key, account.into())
             })
             .collect(),
         cu_avail,

--- a/src/vm_interp.rs
+++ b/src/vm_interp.rs
@@ -3,20 +3,14 @@ use crate::{
     utils::vm::{err_map, mem_regions, HEAP_MAX, STACK_SIZE},
     InstrContext, TOGGLE_DIRECT_MAPPING,
 };
-use agave_feature_set::remove_accounts_executable_flag_checks;
+use agave_feature_set::bpf_account_data_direct_mapping;
 use bincode::Error;
 use prost::Message;
-use solana_account::AccountSharedData;
-use solana_bpf_loader_program::{
-    serialization::serialize_parameters, syscalls::create_program_runtime_environment_v1,
-};
-use solana_compute_budget::compute_budget::ComputeBudget;
+use solana_bpf_loader_program::serialization::serialize_parameters;
 use solana_log_collector::LogCollector;
 use solana_program_runtime::{
     invoke_context::{EnvironmentConfig, InvokeContext},
-    loaded_programs::ProgramCacheForTxBatch,
     mem_pool::VmMemoryPool,
-    sysvar_cache::SysvarCache,
 };
 use solana_sbpf::{
     aligned_memory::AlignedMemory,
@@ -28,16 +22,11 @@ use solana_sbpf::{
     program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
     static_analysis::TraceLogEntry,
     verifier::RequisiteVerifier,
-    vm::{Config, ContextObject, EbpfVm},
+    vm::{ContextObject, EbpfVm},
 };
 
 use solana_program_test::IndexOfAccount;
-use solana_rent::Rent;
-use solana_sdk::{
-    account::WritableAccount, entrypoint::MAX_PERMITTED_DATA_INCREASE,
-    feature_set::bpf_account_data_direct_mapping,
-};
-use solana_transaction_context::{TransactionAccount, TransactionContext};
+use solana_sdk::{account::WritableAccount, entrypoint::MAX_PERMITTED_DATA_INCREASE};
 use std::{borrow::Borrow, cell::RefCell, ffi::c_int, rc::Rc, sync::Arc};
 
 declare_builtin_function!(
@@ -156,97 +145,7 @@ pub fn vec_rtrim_zeros(v: &[u8]) -> Vec<u8> {
 // We are actually executing the JIT-compiled program here
 pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffects> {
     let mut instr_ctx: InstrContext = syscall_context.instr_ctx?.try_into().ok()?;
-    let mut feature_set = instr_ctx.feature_set;
 
-    unsafe {
-        if TOGGLE_DIRECT_MAPPING {
-            // Toggle the BPF direct mapping feature
-            if feature_set
-                .active()
-                .contains_key(&bpf_account_data_direct_mapping::id())
-            {
-                feature_set.deactivate(&bpf_account_data_direct_mapping::id());
-            } else {
-                feature_set.activate(&bpf_account_data_direct_mapping::id(), 0);
-            }
-        }
-    }
-
-    let existing_pubkeys: Vec<_> = instr_ctx
-        .accounts
-        .iter()
-        .map(|(pubkey, _)| pubkey)
-        .collect();
-
-    if !existing_pubkeys.contains(&&instr_ctx.instruction.program_id) {
-        instr_ctx.accounts.push((
-            instr_ctx.instruction.program_id,
-            AccountSharedData::default().into(),
-        ));
-    }
-
-    // Setup here for the vm serialization step
-    let mut transaction_accounts =
-        Vec::<TransactionAccount>::with_capacity(instr_ctx.accounts.len() + 1);
-    #[allow(deprecated)]
-    instr_ctx
-        .accounts
-        .clone()
-        .into_iter()
-        .map(|(pubkey, account)| (pubkey, AccountSharedData::from(account)))
-        .for_each(|x| transaction_accounts.push(x));
-
-    let compute_budget = ComputeBudget {
-        compute_unit_limit: instr_ctx.cu_avail,
-        ..ComputeBudget::default()
-    };
-    let mut transaction_context = TransactionContext::new(
-        transaction_accounts.clone(),
-        Rent::default(),
-        compute_budget.max_instruction_stack_depth,
-        compute_budget.max_instruction_trace_length,
-    );
-    transaction_context.set_remove_accounts_executable_flag_checks(
-        feature_set.is_active(&remove_accounts_executable_flag_checks::id()),
-    );
-
-    let sysvar_cache = SysvarCache::default();
-    #[allow(deprecated)]
-    let (blockhash, lamports_per_signature) = sysvar_cache
-        .get_recent_blockhashes()
-        .ok()
-        .and_then(|x| (*x).last().cloned())
-        .map(|x| (x.blockhash, x.fee_calculator.lamports_per_signature))
-        .unwrap_or_default();
-
-    let environment_config = EnvironmentConfig::new(
-        blockhash,
-        lamports_per_signature,
-        0,
-        &|_| 0u64,
-        Arc::new(feature_set.clone()),
-        &sysvar_cache,
-    );
-
-    let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
-    let log_collector = LogCollector::new_ref();
-    let invoke_context = RefCell::new(InvokeContext::new(
-        &mut transaction_context,
-        &mut program_cache_for_tx_batch,
-        environment_config,
-        Some(log_collector.clone()),
-        compute_budget,
-    ));
-
-    let instr = &instr_ctx.instruction;
-    let instr_accounts = crate::get_instr_accounts(&transaction_accounts, &instr.accounts);
-
-    let program_idx_in_txn = transaction_accounts
-        .iter()
-        .position(|(pubkey, _)| *pubkey == instr_ctx.instruction.program_id)?
-        as IndexOfAccount;
-
-    let mut invoke_ctx: std::cell::RefMut<'_, InvokeContext<'_>> = invoke_context.borrow_mut();
     let vm_ctx = syscall_context.vm_ctx.unwrap();
     let sbpf_version = match vm_ctx.sbpf_version {
         1 => SBPFVersion::V1,
@@ -255,31 +154,78 @@ pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffec
         _ => SBPFVersion::V0,
     };
 
-    /* Enable direct_mapping for SBPF version >= v1 */
     if sbpf_version >= SBPFVersion::V1 {
-        feature_set.activate(&bpf_account_data_direct_mapping::id(), 0);
+        instr_ctx
+            .feature_set
+            .activate(&bpf_account_data_direct_mapping::id(), 0);
     }
 
-    let direct_mapping = sbpf_version >= SBPFVersion::V1
-        || invoke_ctx
-            .get_feature_set()
-            .is_active(&bpf_account_data_direct_mapping::id());
+    let (
+        mut transaction_context,
+        sysvar_cache,
+        mut program_cache_for_tx_batch,
+        blockhash,
+        lamports_per_signature,
+        compute_budget,
+    ) = crate::create_invoke_context_fields(&mut instr_ctx)?;
+
+    let instr = &instr_ctx.instruction;
+
+    unsafe {
+        if TOGGLE_DIRECT_MAPPING {
+            // Toggle the BPF direct mapping feature
+            if instr_ctx
+                .feature_set
+                .active()
+                .contains_key(&bpf_account_data_direct_mapping::id())
+            {
+                instr_ctx
+                    .feature_set
+                    .deactivate(&bpf_account_data_direct_mapping::id());
+            } else {
+                instr_ctx
+                    .feature_set
+                    .activate(&bpf_account_data_direct_mapping::id(), 0);
+            }
+        }
+    }
+
+    let log_collector = LogCollector::new_ref();
+    let instr_accounts = crate::get_instr_accounts(&transaction_context, &instr.accounts);
+
+    let invoke_context = RefCell::new(InvokeContext::new(
+        &mut transaction_context,
+        &mut program_cache_for_tx_batch,
+        EnvironmentConfig::new(
+            blockhash,
+            lamports_per_signature,
+            0,
+            &|_| 0u64,
+            Arc::new(instr_ctx.feature_set.clone()),
+            &sysvar_cache,
+        ),
+        Some(log_collector.clone()),
+        compute_budget,
+    ));
+
+    let mut invoke_ctx: std::cell::RefMut<'_, InvokeContext<'_>> = invoke_context.borrow_mut();
+
+    let program_idx = invoke_ctx
+        .transaction_context
+        .find_index_of_program_account(&instr_ctx.instruction.program_id)?;
+
+    let direct_mapping = invoke_ctx
+        .get_feature_set()
+        .is_active(&bpf_account_data_direct_mapping::id());
+    let mask_out_rent_epoch_in_vm_serialization = invoke_ctx
+        .get_feature_set()
+        .is_active(&agave_feature_set::mask_out_rent_epoch_in_vm_serialization::id());
 
     invoke_ctx
         .transaction_context
         .get_next_instruction_context()
         .unwrap()
-        .configure(
-            &[program_idx_in_txn],
-            instr_accounts.as_slice(),
-            &instr.data,
-        );
-    let mask_out_rent_epoch_in_vm_serialization = invoke_ctx
-        .get_feature_set()
-        .is_active(&agave_feature_set::mask_out_rent_epoch_in_vm_serialization::id());
-    drop(invoke_ctx);
-
-    let mut invoke_ctx: std::cell::RefMut<'_, InvokeContext<'_>> = invoke_context.borrow_mut();
+        .configure(&[program_idx], instr_accounts.as_slice(), &instr.data);
 
     match invoke_ctx.push() {
         Ok(_) => (),
@@ -300,24 +246,16 @@ pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffec
     )
     .unwrap();
 
+    let mut config = invoke_ctx
+        .program_cache_for_tx_batch
+        .environments
+        .program_runtime_v1
+        .get_config()
+        .clone();
+    config.enable_instruction_tracing = true;
+    config.enabled_sbpf_versions = SBPFVersion::V0..=sbpf_version;
+
     drop(invoke_ctx);
-
-    // Load default syscalls, to be stubbed later
-    let unstubbed_runtime = create_program_runtime_environment_v1(
-        &feature_set,
-        &ComputeBudget::default(),
-        false,
-        true, /* capture register state to obtain pc on success */
-    )
-    .unwrap();
-
-    let config = &Config {
-        enabled_sbpf_versions: SBPFVersion::V0..=sbpf_version,
-        enable_stack_frame_gaps: !feature_set.is_active(&bpf_account_data_direct_mapping::id()),
-        aligned_memory_mapping: !feature_set.is_active(&bpf_account_data_direct_mapping::id()),
-        enable_instruction_tracing: true,
-        ..Config::default()
-    };
 
     let mut invoke_ctx = invoke_context.borrow_mut();
     invoke_ctx
@@ -333,7 +271,11 @@ pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffec
     // Stub syscalls
     // Note: unstubbed_runtime is "v1", so syscalls are only registered for version < V3,
     //       i.e. unstubbed_runtime.get_function_registry(sbpf_version) does NOT work.
-    let syscall_reg = unstubbed_runtime.get_function_registry();
+    let syscall_reg = invoke_ctx
+        .program_cache_for_tx_batch
+        .environments
+        .program_runtime_v1
+        .get_function_registry();
     for (_key, (name, _func)) in syscall_reg.iter() {
         loader
             .register_function(std::str::from_utf8(name).unwrap(), SyscallStub::vm)
@@ -405,7 +347,7 @@ pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffec
         }
         Ok(account.data_as_mut_slice().as_mut_ptr() as u64)
     });
-    let memory_mapping = match MemoryMapping::new_with_cow(regions, cow_cb, config, sbpf_version) {
+    let memory_mapping = match MemoryMapping::new_with_cow(regions, cow_cb, &config, sbpf_version) {
         Ok(mapping) => mapping,
         Err(_) => return None,
     };

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -1,5 +1,4 @@
 use crate::{
-    initialize_program_cache,
     proto::{SyscallContext, SyscallEffects},
     utils::err_map::unpack_stable_result,
     utils::vm::mem_regions,
@@ -7,12 +6,9 @@ use crate::{
     utils::vm::STACK_SIZE,
     InstrContext,
 };
-use agave_feature_set::{bpf_account_data_direct_mapping, remove_accounts_executable_flag_checks};
+use agave_feature_set::bpf_account_data_direct_mapping;
 use prost::Message;
-use solana_bpf_loader_program::{
-    serialization::serialize_parameters, syscalls::create_program_runtime_environment_v1,
-};
-use solana_compute_budget::compute_budget::ComputeBudget;
+use solana_bpf_loader_program::serialization::serialize_parameters;
 use solana_log_collector::LogCollector;
 use solana_program_runtime::invoke_context::EnvironmentConfig;
 use solana_program_runtime::sysvar_cache::SysvarCache;
@@ -28,15 +24,8 @@ use solana_sbpf::{
     vm::{ContextObject, EbpfVm},
 };
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::{
-    account::{AccountSharedData, WritableAccount},
-    clock::Clock,
-    entrypoint::MAX_PERMITTED_DATA_INCREASE,
-    epoch_schedule::EpochSchedule,
-    rent::Rent,
-    sysvar::{last_restart_slot, SysvarId},
-};
-use solana_transaction_context::{IndexOfAccount, TransactionAccount, TransactionContext};
+use solana_sdk::{account::WritableAccount, entrypoint::MAX_PERMITTED_DATA_INCREASE};
+use solana_transaction_context::{IndexOfAccount, TransactionContext};
 use std::{cell::RefCell, ffi::c_int, rc::Rc, sync::Arc};
 
 #[no_mangle]
@@ -70,51 +59,28 @@ pub unsafe extern "C" fn sol_compat_vm_syscall_execute_v1(
 pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     let mut instr_ctx: InstrContext = input.instr_ctx?.try_into().ok()?;
 
-    let existing_pubkeys: Vec<_> = instr_ctx
-        .accounts
-        .iter()
-        .map(|(pubkey, _)| pubkey)
-        .collect();
+    let (
+        transaction_context,
+        sysvar_cache,
+        program_cache_for_tx_batch,
+        blockhash,
+        lamports_per_signature,
+        compute_budget,
+    ) = crate::create_invoke_context_fields(&mut instr_ctx)?;
 
-    if !existing_pubkeys.contains(&&instr_ctx.instruction.program_id) {
-        instr_ctx.accounts.push((
-            instr_ctx.instruction.program_id,
-            AccountSharedData::default().into(),
-        ));
-    }
+    /* MemoryCowCallback requires moved objects to have the 'static lifetime
+      so we promote them to 'static and drop at the end as we are sure they are not used anymore
+    */
+    let transaction_context = Box::leak(Box::new(transaction_context));
+    let transaction_context_ptr = transaction_context as *mut TransactionContext as usize;
+    let sysvar_cache = Box::leak(Box::new(sysvar_cache));
+    let sysvar_cache_ptr = sysvar_cache as *mut SysvarCache as usize;
+    let program_cache_for_tx_batch = Box::leak(Box::new(program_cache_for_tx_batch));
+    let program_cache_for_tx_batch_ptr =
+        program_cache_for_tx_batch as *mut ProgramCacheForTxBatch as usize;
 
-    let feature_set = instr_ctx.feature_set;
-
-    let program_runtime_environment_v1 =
-        create_program_runtime_environment_v1(&feature_set, &ComputeBudget::default(), true, false)
-            .unwrap();
-    let config = program_runtime_environment_v1.get_config();
-
-    // Create invoke context
-    // TODO: factor this into common code with lib.rs
-    let mut transaction_accounts =
-        Vec::<TransactionAccount>::with_capacity(instr_ctx.accounts.len() + 1);
-    #[allow(deprecated)]
-    instr_ctx
-        .accounts
-        .clone()
-        .into_iter()
-        .map(|(pubkey, account)| (pubkey, AccountSharedData::from(account)))
-        .for_each(|x| transaction_accounts.push(x));
-
-    let compute_budget = ComputeBudget {
-        compute_unit_limit: instr_ctx.cu_avail,
-        ..ComputeBudget::default()
-    };
-    let mut transaction_context = TransactionContext::new(
-        transaction_accounts.clone(),
-        Rent::default(),
-        compute_budget.max_instruction_stack_depth,
-        compute_budget.max_instruction_trace_length,
-    );
-    transaction_context.set_remove_accounts_executable_flag_checks(
-        feature_set.is_active(&remove_accounts_executable_flag_checks::id()),
-    );
+    let instr = &instr_ctx.instruction;
+    let feature_set = &instr_ctx.feature_set;
 
     if let Some(vm_ctx) = &input.vm_ctx {
         if let Some(return_data) = vm_ctx.return_data.clone() {
@@ -125,79 +91,30 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         }
     }
 
-    // sigh ... What is this mess?
-    let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
-    initialize_program_cache(&mut program_cache_for_tx_batch, &feature_set);
-
-    let mut sysvar_cache = SysvarCache::default();
-
-    sysvar_cache.fill_missing_entries(|pubkey, callbackback| {
-        if let Some(account) = instr_ctx.accounts.iter().find(|(key, _)| key == pubkey) {
-            if account.1.lamports > 0 {
-                callbackback(&account.1.data);
-            }
-        }
-    });
-
-    // Any default values for missing sysvar values should be set here
-    sysvar_cache.fill_missing_entries(|pubkey, callbackback| {
-        if *pubkey == Clock::id() {
-            // Set the default clock slot to something arbitrary beyond 0
-            // This prevents DelayedVisibility errors when executing BPF programs
-            let default_clock = Clock {
-                slot: 10,
-                ..Default::default()
-            };
-            let clock_data = bincode::serialize(&default_clock).unwrap();
-            callbackback(&clock_data);
-        }
-        if *pubkey == EpochSchedule::id() {
-            callbackback(&bincode::serialize(&EpochSchedule::default()).unwrap());
-        }
-        if *pubkey == Rent::id() {
-            callbackback(&bincode::serialize(&Rent::default()).unwrap());
-        }
-        if *pubkey == last_restart_slot::id() {
-            let slot_val = 5000_u64;
-            callbackback(&bincode::serialize(&slot_val).unwrap());
-        }
-    });
-
-    #[allow(deprecated)]
-    let (blockhash, lamports_per_signature) = sysvar_cache
-        .get_recent_blockhashes()
-        .ok()
-        .and_then(|x| (*x).last().cloned())
-        .map(|x| (x.blockhash, x.fee_calculator.lamports_per_signature))
-        .unwrap_or_default();
-
-    let environment_config = EnvironmentConfig::new(
-        blockhash,
-        lamports_per_signature,
-        0,
-        &|_| 0u64,
-        Arc::new(feature_set.clone()),
-        &sysvar_cache,
-    );
     let log_collector = LogCollector::new_ref();
 
+    let instr_accounts = crate::get_instr_accounts(transaction_context, &instr.accounts);
+
     let invoke_context = RefCell::new(InvokeContext::new(
-        &mut transaction_context,
-        &mut program_cache_for_tx_batch,
-        environment_config,
+        transaction_context,
+        program_cache_for_tx_batch,
+        EnvironmentConfig::new(
+            blockhash,
+            lamports_per_signature,
+            0,
+            &|_| 0u64,
+            Arc::new(feature_set.clone()),
+            sysvar_cache,
+        ),
         Some(log_collector.clone()),
         compute_budget,
     ));
 
-    let instr = &instr_ctx.instruction;
-    let instr_accounts = crate::get_instr_accounts(&transaction_accounts, &instr.accounts);
-
-    let program_idx_in_txn = transaction_accounts
-        .iter()
-        .position(|(pubkey, _)| *pubkey == instr_ctx.instruction.program_id)?
-        as IndexOfAccount;
-
     let mut invoke_ctx: std::cell::RefMut<'_, InvokeContext<'_>> = invoke_context.borrow_mut();
+
+    let program_idx = invoke_ctx
+        .transaction_context
+        .find_index_of_program_account(&instr_ctx.instruction.program_id)?;
     let direct_mapping = invoke_ctx
         .get_feature_set()
         .is_active(&bpf_account_data_direct_mapping::id());
@@ -208,14 +125,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         .transaction_context
         .get_next_instruction_context()
         .unwrap()
-        .configure(
-            &[program_idx_in_txn],
-            instr_accounts.as_slice(),
-            &instr.data,
-        );
-    drop(invoke_ctx);
-
-    let mut invoke_ctx = invoke_context.borrow_mut();
+        .configure(&[program_idx], instr_accounts.as_slice(), &instr.data);
 
     match invoke_ctx.push() {
         Ok(_) => (),
@@ -265,6 +175,26 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     //   - input data is made of multiple regions, and regions don't necessarily have
     //     length multiple of 16, i.e. virtual addresses may be unaligned
     // These differences allow us to test more edge cases.
+    let mut invoke_ctx = invoke_context.borrow_mut();
+    let config = invoke_ctx
+        .program_cache_for_tx_batch
+        .environments
+        .program_runtime_v1
+        .get_config()
+        .clone();
+    let (_, syscall_func) = invoke_ctx
+        .program_cache_for_tx_batch
+        .environments
+        .program_runtime_v1
+        .get_function_registry()
+        .lookup_by_name(
+            &input
+                .syscall_invocation
+                .clone()
+                .unwrap_or_default()
+                .function_name,
+        )?;
+
     let mut mempool = VmMemoryPool::new();
     let rodata = AlignedMemory::<HOST_ALIGN>::from(&vm_ctx.rodata);
     let mut stack = mempool.get_stack(STACK_SIZE);
@@ -288,8 +218,6 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         .chain(input_memory_regions)
         .collect();
 
-    let mut invoke_ctx = invoke_context.borrow_mut();
-
     let cow_cb_accounts = Rc::clone(invoke_ctx.transaction_context.accounts());
     let cow_cb = Box::new(move |index_in_transaction| {
         let mut account = cow_cb_accounts
@@ -305,7 +233,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         }
         Ok(account.data_as_mut_slice().as_mut_ptr() as u64)
     });
-    let memory_mapping = match MemoryMapping::new_with_cow(regions, cow_cb, config, sbpf_version) {
+    let memory_mapping = match MemoryMapping::new_with_cow(regions, cow_cb, &config, sbpf_version) {
         Ok(mapping) => mapping,
         Err(_) => return None,
     };
@@ -340,18 +268,22 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     vm.registers[10] = vm_ctx.r10;
     vm.registers[11] = vm_ctx.r11;
 
-    if let Some(syscall_invocation) = input.syscall_invocation.clone() {
+    if let Some(syscall_invocation) = input.syscall_invocation {
         mem_regions::copy_memory_prefix(heap.as_slice_mut(), &syscall_invocation.heap_prefix);
         mem_regions::copy_memory_prefix(stack.as_slice_mut(), &syscall_invocation.stack_prefix);
     }
 
-    // Actually invoke the syscall
-
     // Invoke the syscall
-    let (_, syscall_func) = program_runtime_environment_v1
-        .get_function_registry()
-        .lookup_by_name(&input.syscall_invocation?.function_name)?;
     vm.invoke_function(syscall_func);
+
+    // Drop the 'static objects created at the beginning of the function
+    unsafe {
+        let _transaction_context_droppable =
+            Box::from_raw(transaction_context_ptr as *mut TransactionContext);
+        let _sysvar_cache_droppable = Box::from_raw(sysvar_cache_ptr as *mut SysvarCache);
+        let _program_cache_for_tx_batch_droppable =
+            Box::from_raw(program_cache_for_tx_batch_ptr as *mut ProgramCacheForTxBatch);
+    }
 
     // Unwrap and return the effects of the syscall
     let program_id = instr_ctx.instruction.program_id;

--- a/tests/txn_fuzzer_sanity.rs
+++ b/tests/txn_fuzzer_sanity.rs
@@ -1,14 +1,15 @@
+use agave_feature_set::set_exempt_rent_epoch_max;
 use prost::Message;
 use solana_program::bpf_loader_upgradeable;
 use solana_program::bpf_loader_upgradeable::UpgradeableLoaderState;
 use solana_program::hash::Hash;
 use solana_program::pubkey::Pubkey;
+use solana_sdk::address_lookup_table;
 use solana_sdk::clock::Clock;
 use solana_sdk::epoch_schedule::EpochSchedule;
 use solana_sdk::rent::Rent;
 use solana_sdk::signature::Signature;
 use solana_sdk::sysvar::SysvarId;
-use solana_sdk::{address_lookup_table, feature_set::*};
 use solfuzz_agave::proto::{
     AcctState, CompiledInstruction, EpochContext, FeatureSet, MessageHeader, SanitizedTransaction,
     SlotContext, TransactionMessage, TxnContext, TxnResult,


### PR DESCRIPTION
* Factors out common instruction setup code into a helper function
* Correctly populates program cache for CPI execution (fixes the CPI harness)