### PR TITLE
perf, skip some syscalls

### DIFF
--- a/src/txn_fuzzer.rs
+++ b/src/txn_fuzzer.rs
@@ -435,7 +435,7 @@ pub fn execute_transaction(context: &TxnContext) -> Option<TxnResult> {
     let bank = Bank::new_with_paths(
         &genesis_config,
         Arc::new(RuntimeConfig::default()),
-        vec![],
+        vec!["/dev/shm/a".into()],
         None,
         None,
         false,


### PR DESCRIPTION
```
txn-fixture-exec/100-fixtures-batch
                        time:   [278.79 ms 280.18 ms 281.71 ms]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
txn-fixture-exec/single-transaction
                        time:   [3.2710 ms 3.2968 ms 3.3262 ms]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
txn-fixture-exec/small-batch-10
                        time:   [41.640 ms 41.948 ms 42.306 ms]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
  ```
^^ before







vv after
```txt
txn-fixture-exec/100-fixtures-batch
                        time:   [205.50 ms 206.26 ms 207.05 ms]
                        change: [-26.871% -26.383% -25.918%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
txn-fixture-exec/single-transaction
                        time:   [2.4907 ms 2.5022 ms 2.5145 ms]
                        change: [-24.870% -24.102% -23.410%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
txn-fixture-exec/small-batch-10
                        time:   [34.493 ms 34.670 ms 34.859 ms]
                        change: [-18.158% -17.349% -16.587%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
  ```