### PR TITLE
chore: fix cargo dep. warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,39 +85,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "agave-cargo-registry"
-version = "2.2.13"
-source = "git+https://github.com/firedancer-io/agave?rev=f5bed6630a#f5bed6630a541549f8c91b4c6fe5adf1f07cf594"
-dependencies = [
- "clap 2.34.0",
- "flate2",
- "hex",
- "hyper 0.14.32",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.10.8",
- "solana-clap-utils",
- "solana-cli",
- "solana-cli-config",
- "solana-cli-output",
- "solana-commitment-config",
- "solana-keypair",
- "solana-logger",
- "solana-pubkey 2.2.1",
- "solana-remote-wallet",
- "solana-rpc-client",
- "solana-rpc-client-api",
- "solana-signer",
- "solana-version",
- "tar",
- "tempfile",
- "tokio",
- "toml 0.8.20",
-]
-
-[[package]]
 name = "agave-feature-set"
 version = "2.2.13"
 source = "git+https://github.com/firedancer-io/agave?rev=f5bed6630a#f5bed6630a541549f8c91b4c6fe5adf1f07cf594"
@@ -10388,24 +10355,6 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk-ids",
  "solana-zk-sdk",
-]
-
-[[package]]
-name = "solana-zk-keygen"
-version = "2.2.13"
-source = "git+https://github.com/firedancer-io/agave?rev=f5bed6630a#f5bed6630a541549f8c91b4c6fe5adf1f07cf594"
-dependencies = [
- "bs58",
- "clap 3.2.25",
- "dirs-next",
- "solana-clap-v3-utils",
- "solana-remote-wallet",
- "solana-seed-derivable",
- "solana-signer",
- "solana-version",
- "solana-zk-token-sdk",
- "thiserror 2.0.12",
- "tiny-bip39",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,7 +1347,6 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_derive 3.2.25",
  "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
@@ -1363,7 +1362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.18",
+ "clap_derive",
 ]
 
 [[package]]
@@ -1376,19 +1375,6 @@ dependencies = [
  "anstyle",
  "clap_lex 0.7.2",
  "strsim 0.11.1",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4582,30 +4568,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -10540,7 +10502,6 @@ dependencies = [
  "Inflector",
  "aes-gcm-siv",
  "agave-banking-stage-ingress-types",
- "agave-cargo-registry",
  "agave-feature-set",
  "agave-geyser-plugin-interface",
  "agave-precompiles",
@@ -10913,7 +10874,6 @@ dependencies = [
  "solana-vote-program",
  "solana-wen-restart",
  "solana-zk-elgamal-proof-program",
- "solana-zk-keygen",
  "solana-zk-sdk",
  "solana-zk-token-proof-program",
  "solana-zk-token-sdk",
@@ -13090,8 +13050,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "crossbeam-epoch"
-version = "0.9.5"
-source = "git+https://github.com/anza-xyz/crossbeam?rev=fd279d707025f0e60951e429bf778b4813d1b6bf#fd279d707025f0e60951e429bf778b4813d1b6bf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ lto = "thin"
 opt-level = 3
 
 [patch.crates-io]
-# for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
-crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
-
 # We include the following crates as our dependencies above from crates.io:
 #
 #  * spl-associated-token-account

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ lto = "thin"
 opt-level = 3
 
 [patch.crates-io]
+# for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
+
 # We include the following crates as our dependencies above from crates.io:
 #
 #  * spl-associated-token-account

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,7 +273,6 @@ solana-bpf-loader-program = {git = "https://github.com/firedancer-io/agave", rev
 solana-bucket-map = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
 solana-builtins = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
 solana-builtins-default-costs = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
-agave-cargo-registry = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
 agave-thread-manager = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
 solana-clap-utils = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
 solana-clap-v3-utils = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
@@ -444,7 +443,6 @@ solana-vote-interface = "2.2.3"
 solana-vote-program = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
 solana-wen-restart = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
 solana-zk-elgamal-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
-solana-zk-keygen = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
 solana-zk-sdk = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
 solana-zk-token-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}
 solana-zk-token-sdk = {git = "https://github.com/firedancer-io/agave", rev = "f5bed6630a"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+# This file is auto generated. See generate_cargo.py
 [profile.release-with-debug]
 inherits = "release"
 debug = true

--- a/scripts/generate_cargo.py
+++ b/scripts/generate_cargo.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = [
+#     "tomlkit",
+# ]
+# ///
+
 import argparse
 from tomlkit import parse, inline_table, table
 import re
@@ -102,9 +109,14 @@ def main():
 
     # some clean up
     toml_data["package"] = table()
-    for dep_to_remove in ["pickledb", "winreg", "solana-sdk", "solana-program", "once_cell"]:
+    print(toml_data)
+    for dep_to_remove in ["pickledb", "winreg", "solana-sdk", "solana-program", "once_cell", "agave-cargo-registry", "solana-zk-keygen"]:
         if dep_to_remove in toml_data.get("dependencies", {}):
             del toml_data["dependencies"][dep_to_remove]
+
+    for patch_to_remove in ["crossbeam-epoch",]:
+        if patch_to_remove in toml_data.get("patch", {}).get("crates-io", {}):
+            del toml_data["patch"]["crates-io"][patch_to_remove]
 
     # add required solfuzz-agave added configurations
     solfuzz_agave_config = parse_toml_file("solfuzz_agave.toml")
@@ -127,6 +139,7 @@ def main():
 
     # Write the updated data to the output TOML file
     with open(args.output, "w") as f:
+        f.write("# This file is auto generated. See generate_cargo.py\n")
         f.write(toml_data.as_string())
 
 if __name__ == "__main__":

--- a/scripts/generate_cargo.py
+++ b/scripts/generate_cargo.py
@@ -109,7 +109,6 @@ def main():
 
     # some clean up
     toml_data["package"] = table()
-    print(toml_data)
     for dep_to_remove in ["pickledb", "winreg", "solana-sdk", "solana-program", "once_cell", "agave-cargo-registry", "solana-zk-keygen"]:
         if dep_to_remove in toml_data.get("dependencies", {}):
             del toml_data["dependencies"][dep_to_remove]
@@ -120,7 +119,6 @@ def main():
 
     # add required solfuzz-agave added configurations
     solfuzz_agave_config = parse_toml_file("solfuzz_agave.toml")
-    print(solfuzz_agave_config)
     for section, values in solfuzz_agave_config.items():
         if section not in toml_data:
             toml_data[section] = table()


### PR DESCRIPTION
```
warning: Patch `crossbeam-epoch v0.9.5 (https://github.com/anza-xyz/crossbeam?rev=fd279d707025f0e60951e429bf778b4813d1b6bf#fd279d70)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.
warning: solfuzz-agave v0.1.0 (/root/solfuzz-agave) ignoring invalid dependency `agave-cargo-registry` which is missing a lib target
warning: solfuzz-agave v0.1.0 (/root/solfuzz-agave) ignoring invalid dependency `solana-zk-keygen` which is missing a lib target
```