### PR TITLE
chore: do not build with trace-cmp by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ RUSTFLAGS+=-Cpasses=sancov-module
 RUSTFLAGS+=-Cllvm-args=-sanitizer-coverage-inline-8bit-counters
 RUSTFLAGS+=-Cllvm-args=-sanitizer-coverage-level=4
 RUSTFLAGS+=-Cllvm-args=-sanitizer-coverage-pc-table
-RUSTFLAGS+=-Cllvm-args=-sanitizer-coverage-trace-compares
 RUSTFLAGS+=-Clink-dead-code
 RUSTFLAGS+=-Cforce-frame-pointers=yes
 RUSTFLAGS+=-Ctarget-feature=-crt-static


### PR DESCRIPTION
Firedancer isn't currently built with trace compare instrumentation and CMPLOG isn't being used on average, so I think this just adds needless overhead https://github.com/firedancer-io/firedancer/blob/main/config/extra/with-fuzz.mk