### PR TITLE
fix: use the program v1 runtime config created

### DIFF
--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -303,7 +303,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         .unwrap();
 
     // Set up the vm instance
-    let loader = std::sync::Arc::new(BuiltinProgram::new_mock());
+    let loader = std::sync::Arc::new(BuiltinProgram::new_loader(config.clone()));
     let mut vm = EbpfVm::new(
         loader,
         sbpf_version,


### PR DESCRIPTION
`new_mock` uses `Config::default()` and not what Agave actually uses.

The v1 config is already set and used to set up the memory mapping
https://github.com/firedancer-io/solfuzz-agave/blob/2fb6c4b846c66a9a86fb92304aa742c457b03adc/src/vm_syscalls.rs#L87
https://github.com/firedancer-io/solfuzz-agave/blob/2fb6c4b846c66a9a86fb92304aa742c457b03adc/src/lib.rs#L788
https://github.com/firedancer-io/solfuzz-agave/blob/2fb6c4b846c66a9a86fb92304aa742c457b03adc/src/vm_syscalls.rs#L227