### PR TITLE
feat: wire up ABIv2 feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,6 +313,7 @@ static SUPPORTED_FEATURES: &[u64] = feature_list![
     require_static_nonce_account,
     enable_vote_address_leader_schedule,
     enshrine_slashing_program,
+    // stricter_abi_and_runtime_constraints // NOT supported in fd
 ];
 
 // If `TOGGLE_DIRECT_MAPPING=1` is set, the direct mapping feature will be inverted, testing with and without direct mapping.

--- a/src/vm_interp.rs
+++ b/src/vm_interp.rs
@@ -195,6 +195,9 @@ pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffec
             direct_mapping = !direct_mapping;
         }
     }
+    let stricter_abi_and_runtime_constraints = invoke_ctx
+        .get_feature_set()
+        .stricter_abi_and_runtime_constraints;
     let mask_out_rent_epoch_in_vm_serialization = invoke_ctx
         .get_feature_set()
         .mask_out_rent_epoch_in_vm_serialization;
@@ -217,7 +220,7 @@ pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffec
         .unwrap();
     let (_aligned_memory, input_memory_regions, acc_metadatas) = serialize_parameters(
         &caller_instr_ctx,
-        false,
+        stricter_abi_and_runtime_constraints,
         direct_mapping,
         mask_out_rent_epoch_in_vm_serialization,
     )
@@ -315,7 +318,7 @@ pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffec
         sbpf_version,
         invoke_ctx
             .transaction_context
-            .access_violation_handler(false, direct_mapping),
+            .access_violation_handler(stricter_abi_and_runtime_constraints, direct_mapping),
     ) else {
         return None;
     };

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -155,6 +155,9 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
             direct_mapping = !direct_mapping;
         }
     };
+    let stricter_abi_and_runtime_constraints = invoke_ctx
+        .get_feature_set()
+        .stricter_abi_and_runtime_constraints;
     let mask_out_rent_epoch_in_vm_serialization = invoke_ctx
         .get_feature_set()
         .mask_out_rent_epoch_in_vm_serialization;
@@ -194,7 +197,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     // The stack gap size is 0 iff direct mapping is enabled.
     let (_aligned_memory, input_memory_regions, acc_metadatas) = serialize_parameters(
         &caller_instr_ctx,
-        false,
+        stricter_abi_and_runtime_constraints,
         direct_mapping,
         mask_out_rent_epoch_in_vm_serialization,
     )
@@ -277,7 +280,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         sbpf_version,
         invoke_ctx
             .transaction_context
-            .access_violation_handler(false, direct_mapping),
+            .access_violation_handler(stricter_abi_and_runtime_constraints, direct_mapping),
     ) else {
         cleanup_static_ptrs(
             transaction_context_ptr,

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -183,6 +183,15 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         .transaction_context
         .get_current_instruction_context()
         .unwrap();
+    // Memory regions.
+    // In Agave all memory regions are AlignedMemory::<HOST_ALIGN> == AlignedMemory::<16>,
+    // i.e. they're all 16-byte aligned in the host.
+    // The memory regions are:
+    //   1. program rodata
+    //   2. stack
+    //   3. heap
+    //   4. input data aka accounts
+    // The stack gap size is 0 iff direct mapping is enabled.
     let (_aligned_memory, input_memory_regions, acc_metadatas) = serialize_parameters(
         &caller_instr_ctx,
         false,
@@ -209,24 +218,6 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         return None;
     }
 
-    // Memory regions.
-    // In Agave all memory regions are AlignedMemory::<HOST_ALIGN> == AlignedMemory::<16>,
-    // i.e. they're all 16-byte aligned in the host.
-    // The memory regions are:
-    //   1. program rodata
-    //   2. stack
-    //   3. heap
-    //   4. input data aka accounts
-    // The stack gap is size is 0 iff direct mapping is enabled.
-    // There's some extra quirks:
-    //   - heap size is MIN_HEAP_FRAME_BYTES..=MAX_HEAP_FRAME_BYTES
-    //   - input data (at least when direct mapping is off) is 1 single map of all
-    //     serialized accounts (and each account is serialized to a multiple of 16 bytes)
-    // In this implementation, however:
-    //   - heap can be smaller than MIN_HEAP_FRAME_BYTES
-    //   - input data is made of multiple regions, and regions don't necessarily have
-    //     length multiple of 16, i.e. virtual addresses may be unaligned
-    // These differences allow us to test more edge cases.
     let mut invoke_ctx = invoke_context.borrow_mut();
     let config = invoke_ctx
         .program_cache_for_tx_batch
@@ -301,7 +292,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     invoke_ctx
         .set_syscall_context(solana_program_runtime::invoke_context::SyscallContext {
             allocator: solana_program_runtime::invoke_context::BpfAllocator::new(vm_ctx.heap_max),
-            accounts_metadata: acc_metadatas, // TODO: accounts metadata for direct mapping support
+            accounts_metadata: acc_metadatas,
             trace_log: Vec::new(),
         })
         .unwrap();


### PR DESCRIPTION
Not yet supported in FD, but minimizes my local diff

The memory region comment from https://github.com/firedancer-io/solfuzz-agave/commit/9e670a00922cdea8103243ce717ad3b397fb62ae seems inaccurate following https://github.com/firedancer-io/solfuzz-agave/pull/208 switching to `serialize_paramemters`
