### PR TITLE
Reproducible builds: generate cargo files with pinned deps from Agave

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-cargo-registry"
+version = "3.0.3"
+source = "git+https://github.com/firedancer-io/agave?rev=5ca585786b6e0f95914c0866c7e40a257290f61c#5ca585786b6e0f95914c0866c7e40a257290f61c"
+dependencies = [
+ "clap 2.34.0",
+ "flate2",
+ "hex",
+ "hyper 0.14.32",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.9",
+ "solana-clap-utils",
+ "solana-cli",
+ "solana-cli-config",
+ "solana-cli-output",
+ "solana-commitment-config",
+ "solana-keypair",
+ "solana-logger",
+ "solana-pubkey 3.0.0",
+ "solana-remote-wallet",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-signer",
+ "solana-version",
+ "tar",
+ "tempfile",
+ "tokio",
+ "toml 0.8.23",
+]
+
+[[package]]
 name = "agave-feature-set"
 version = "3.0.3"
 source = "git+https://github.com/firedancer-io/agave?rev=5ca585786b6e0f95914c0866c7e40a257290f61c#5ca585786b6e0f95914c0866c7e40a257290f61c"
@@ -1446,6 +1479,7 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
+ "clap_derive 3.2.25",
  "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
@@ -1461,7 +1495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
- "clap_derive",
+ "clap_derive 4.5.45",
 ]
 
 [[package]]
@@ -5623,7 +5657,7 @@ dependencies = [
  "tokio-rustls 0.24.1",
  "tokio-util 0.7.16",
  "tower-service",
- "url 2.5.7",
+ "url 2.5.6",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -5666,7 +5700,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-http",
  "tower-service",
- "url 2.5.7",
+ "url 2.5.6",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -6507,6 +6541,8 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f4691b69b172c687d218dd2f1f23fc7ea5e9aa79df9ac26dab3d8dd829ce48"
 dependencies = [
+ "bincode",
+ "serde",
  "solana-program-error",
  "solana-program-memory",
  "solana-pubkey 3.0.0",
@@ -6951,7 +6987,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tiny-bip39",
  "uriparse",
- "url 2.5.7",
+ "url 2.5.6",
 ]
 
 [[package]]
@@ -6980,7 +7016,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tiny-bip39",
  "uriparse",
- "url 2.5.7",
+ "url 2.5.6",
 ]
 
 [[package]]
@@ -7081,7 +7117,7 @@ dependencies = [
  "serde_yaml",
  "solana-clap-utils",
  "solana-commitment-config",
- "url 2.5.7",
+ "url 2.5.6",
 ]
 
 [[package]]
@@ -7645,6 +7681,16 @@ dependencies = [
  "solana-sdk-ids 3.0.0",
  "solana-sdk-macro",
  "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-epoch-stake"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc6693d0ea833b880514b9b88d95afb80b42762dca98b0712465d1fcbbcb89e"
+dependencies = [
+ "solana-define-syscall 3.0.0",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -8453,7 +8499,7 @@ dependencies = [
  "socket2 0.6.0",
  "solana-serde",
  "tokio",
- "url 2.5.7",
+ "url 2.5.6",
 ]
 
 [[package]]
@@ -8634,6 +8680,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-program"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91b12305dd81045d705f427acd0435a2e46444b65367d7179d7bdcfc3bc5f5eb"
+dependencies = [
+ "memoffset",
+ "solana-account-info",
+ "solana-big-mod-exp",
+ "solana-blake3-hasher",
+ "solana-clock",
+ "solana-cpi",
+ "solana-define-syscall 3.0.0",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-epoch-stake",
+ "solana-example-mocks",
+ "solana-fee-calculator",
+ "solana-hash 3.0.0",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-instructions-sysvar",
+ "solana-keccak-hasher",
+ "solana-last-restart-slot",
+ "solana-msg",
+ "solana-native-token",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-rent",
+ "solana-sdk-ids 3.0.0",
+ "solana-secp256k1-recover",
+ "solana-serde-varint",
+ "solana-serialize-utils",
+ "solana-sha256-hasher 3.0.0",
+ "solana-short-vec",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-stable-layout",
+ "solana-sysvar",
+ "solana-sysvar-id",
+]
+
+[[package]]
 name = "solana-program-entrypoint"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8653,6 +8745,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1af32c995a7b692a915bb7414d5f8e838450cf7c70414e763d8abcae7b51f28"
 dependencies = [
  "borsh",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -8834,7 +8928,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tungstenite",
- "url 2.5.7",
+ "url 2.5.6",
 ]
 
 [[package]]
@@ -9877,6 +9971,8 @@ checksum = "63205e68d680bcc315337dec311b616ab32fea0a612db3b883ce4de02e0953f9"
 dependencies = [
  "base64 0.22.1",
  "bincode",
+ "bytemuck",
+ "bytemuck_derive",
  "lazy_static",
  "serde",
  "serde_derive",
@@ -10467,6 +10563,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-zk-keygen"
+version = "3.0.3"
+source = "git+https://github.com/firedancer-io/agave?rev=5ca585786b6e0f95914c0866c7e40a257290f61c#5ca585786b6e0f95914c0866c7e40a257290f61c"
+dependencies = [
+ "bs58",
+ "clap 3.2.25",
+ "dirs-next",
+ "solana-clap-v3-utils",
+ "solana-remote-wallet",
+ "solana-seed-derivable",
+ "solana-signer",
+ "solana-version",
+ "solana-zk-sdk",
+ "thiserror 2.0.16",
+ "tiny-bip39",
+]
+
+[[package]]
 name = "solana-zk-sdk"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10560,6 +10674,7 @@ dependencies = [
  "Inflector",
  "aes-gcm-siv",
  "agave-banking-stage-ingress-types",
+ "agave-cargo-registry",
  "agave-feature-set",
  "agave-geyser-plugin-interface",
  "agave-io-uring",
@@ -10849,6 +10964,7 @@ dependencies = [
  "solana-poseidon",
  "solana-precompile-error",
  "solana-presigner",
+ "solana-program",
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-memory",
@@ -10932,6 +11048,7 @@ dependencies = [
  "solana-vote-program",
  "solana-wen-restart",
  "solana-zk-elgamal-proof-program",
+ "solana-zk-keygen",
  "solana-zk-sdk",
  "solana-zk-token-proof-program",
  "solana-zk-token-sdk",
@@ -10978,7 +11095,7 @@ dependencies = [
  "tungstenite",
  "unwrap_none",
  "uriparse",
- "url 2.5.7",
+ "url 2.5.6",
  "vec_extract_if_polyfill",
  "wasm-bindgen",
  "winapi 0.3.9",
@@ -12178,7 +12295,7 @@ dependencies = [
  "rustls 0.21.12",
  "sha1",
  "thiserror 1.0.69",
- "url 2.5.7",
+ "url 2.5.6",
  "utf-8",
  "webpki-roots 0.24.0",
 ]
@@ -12318,14 +12435,13 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "137a3c834eaf7139b73688502f3f1141a0337c5d8e4d9b536f9b8c796e26a7c4"
 dependencies = [
  "form_urlencoded",
  "idna 1.1.0",
  "percent-encoding 2.3.2",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ git = "https://github.com/firedancer-io/agave"
 rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
 
 [package]
-name = "solfuzz-agave"
 version = "0.1.0"
 edition = "2021"
+name = "solfuzz-agave"
 
 [lints.rust]
 warnings = "deny"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+certifi==2025.10.5
+charset-normalizer==3.4.4
+idna==3.11
+requests==2.32.5
+tomli_w==1.2.0
+tomlkit==0.13.3
+urllib3==2.5.0

--- a/scripts/generate_cargo.py
+++ b/scripts/generate_cargo.py
@@ -2,14 +2,20 @@
 # /// script
 # dependencies = [
 #     "tomlkit",
+#     "requests",
+#     "tomli-w",
 # ]
 # ///
 
 import argparse
 from tomlkit import parse, inline_table, table
-import re
 import os
 import subprocess
+from pathlib import Path
+import sys
+import requests
+import time
+import random
 
 # NOTE: this needs bumped with schema version upgrades of the protocol
 PROTOSOL_VERSION_TAG = "v1.0.5"
@@ -48,7 +54,7 @@ def replace_path_with_local(toml_data, local_path):
                 if "path" in value:
                     # Replace path with local path
                     new_table = inline_table()
-                    new_table["path"] = local_path + "/" + value["path"]
+                    new_table["path"] = os.path.join(local_path, value["path"])
                     toml_data[key] = new_table
                 else:
                     replace_path_with_local(value, local_path)
@@ -80,18 +86,134 @@ def parse_toml_file(file_path):
     with open(file_path, "r") as f:
         return parse(f.read())
 
+def download_file(url, dest_path, timeout_seconds: int = 30, max_retries: int = 3, backoff_base: float = 0.5) -> None:
+    """Download a URL to dest_path with retries, exponential backoff, and jitter.
+    Retries on timeouts, connection errors, and 5xx HTTP responses.
+    """
+    last_err = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = requests.get(url, stream=True, timeout=timeout_seconds)
+            # Retry only on 5xx errors; raise for others
+            if 500 <= response.status_code < 600:
+                response.raise_for_status()
+            response.raise_for_status()
+            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+            with open(dest_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
+            return
+        except requests.Timeout as e:
+            last_err = e
+        except requests.ConnectionError as e:
+            last_err = e
+        except requests.HTTPError as e:
+            # Only retry on 5xx
+            status = getattr(e.response, "status_code", None)
+            if status is not None and 500 <= status < 600:
+                last_err = e
+            else:
+                raise
+
+        if attempt < max_retries:
+            sleep_secs = backoff_base * (2 ** (attempt - 1)) + random.uniform(0, backoff_base)
+            time.sleep(sleep_secs)
+
+    if last_err:
+        raise last_err
+
+def remove_unwanted_package_metadata(toml_data):
+    """Remove unwanted fields from the top-level package metadata."""
+    for key in ["authors", "repository", "homepage", "license"]:
+        if key in toml_data.get("package", {}):
+            del toml_data["package"][key]
+
+def prepare_agave_manifest(toml_data, rewrite_paths_fn):
+    """Apply common transformations to the Agave manifest then rewrite paths.
+
+    - Flatten the workspace section
+    - Remove unwanted package metadata
+    - Apply a provided path rewrite function (local or git+rev)
+    """
+    flatten_workspace(toml_data)
+    remove_unwanted_package_metadata(toml_data)
+    rewrite_paths_fn(toml_data)
+
+def strip_metadata(version: str) -> str:
+    """Strip build metadata from a version string"""
+    return version.split("+", 1)[0]
+
+def pin_dependencies(toml_data, lockfile_path):
+    """Pin all deps in Cargo.toml to exact versions from Cargo.lock"""
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib
+    import tomli_w
+
+    with open(lockfile_path, "rb") as f:
+        lock_data = tomllib.load(f)
+    version_map = {pkg["name"]: pkg["version"] for pkg in lock_data.get("package", [])}
+
+    sections = ["dependencies", "dev-dependencies", "build-dependencies"]
+    pinned_names = set()
+
+    for section in sections:
+        deps = toml_data.get(section, {})
+        for dep_name, val in deps.items():
+            if isinstance(val, str):
+                package_name = dep_name
+            elif isinstance(val, dict):
+                package_name = val.get("package", dep_name)
+            else:
+                package_name = dep_name
+
+            if package_name in pinned_names:
+                continue
+            pinned_names.add(package_name)
+
+            if package_name not in version_map:
+                continue
+
+            pinned_version = strip_metadata(version_map[package_name])
+            exact_version_str = f"={pinned_version}"
+
+            def is_exact_pinned(v):
+                if isinstance(v, str):
+                    return v.strip() == exact_version_str
+                elif isinstance(v, dict):
+                    return str(v.get("version", "")).strip() == exact_version_str
+                return False
+
+            if is_exact_pinned(val):
+                continue
+
+            if isinstance(val, str):
+                deps[dep_name] = exact_version_str
+            elif isinstance(val, dict):
+                val["version"] = exact_version_str
+
 def main():
     global PROTOSOL_VERSION_TAG
 
-    parser = argparse.ArgumentParser(description="Process input files.")
+    parser = argparse.ArgumentParser(description="Generate pinned Cargo.toml from Agave.")
 
-    # # Add flags
-    parser.add_argument("--commit", "-c", help="Commit in firedancer-io/agave to use")
-    parser.add_argument("--agave-path", "-p", help="Commit in firedancer-io/agave to use")
-    parser.add_argument("--output", "-o", help="Path to the output file")
-    parser.add_argument("--version", "-v", help=f"Protosol version to use (e.g. \"{PROTOSOL_VERSION_TAG}\")")
+    # Add flags
+    parser.add_argument("--commit", "-c", help="Commit SHA in firedancer-io/agave to use")
+    parser.add_argument("--agave-path", "-p", help="Path to local agave repo")
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=os.path.join(os.getcwd(), "Cargo.toml"),
+        help="Path to the output Cargo.toml (default: Cargo.toml in the current working directory)")
+    parser.add_argument("--version", "-v", help=f"Protosol version to use (default {PROTOSOL_VERSION_TAG})")
 
     args = parser.parse_args()
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        return 1
+
     if args.version:
         PROTOSOL_VERSION_TAG = args.version
         # Prepend 'v' if not already present
@@ -100,29 +222,35 @@ def main():
     print(f"Using protosol version: {PROTOSOL_VERSION_TAG}")
 
     if args.agave_path:
-        toml_data = parse_toml_file(args.agave_path + "/Cargo.toml")
-        flatten_workspace(toml_data)
-        replace_path_with_local(toml_data, args.agave_path)
+        agave_path_abs = os.path.abspath(args.agave_path)
+        toml_data = parse_toml_file(os.path.join(agave_path_abs, "Cargo.toml"))
+        prepare_agave_manifest(toml_data, lambda td: replace_path_with_local(td, agave_path_abs))
+        lockfile_path = os.path.join(agave_path_abs, "Cargo.lock")
     else:
-        url = f"https://raw.githubusercontent.com/firedancer-io/agave/{args.commit}/Cargo.toml"
+        base_url = f"https://raw.githubusercontent.com/firedancer-io/agave/{args.commit}"
         os.makedirs("dump", exist_ok=True)
         try:
-            subprocess.run(
-                ["curl", "-o", os.path.join("dump", "Cargo.toml"), url],
-                check=True
-            )
-        except subprocess.CalledProcessError as e:
-            print(f"Error occurred while downloading the file: {e}")
-
+            download_file(f"{base_url}/Cargo.toml", os.path.join("dump", "Cargo.toml"))
+            download_file(f"{base_url}/Cargo.lock", os.path.join("dump", "Cargo.lock"))
+        except requests.HTTPError as e:
+            print(f"HTTP error while downloading Agave files: {e}")
+            return 1
+        except requests.RequestException as e:
+            print(f"Network error while downloading Agave files: {e}")
+            return 1
         toml_data = parse_toml_file("dump/Cargo.toml")
-        flatten_workspace(toml_data)
-        replace_path_with_git_rev(toml_data, "https://github.com/firedancer-io/agave", args.commit)
+        prepare_agave_manifest(
+            toml_data,
+            lambda td: replace_path_with_git_rev(td, "https://github.com/firedancer-io/agave", args.commit),
+        )
+        lockfile_path = "dump/Cargo.lock"
 
-    # some clean up
-    toml_data["package"] = table()
-    for dep_to_remove in ["pickledb", "winreg", "solana-sdk", "solana-program", "once_cell", "agave-cargo-registry", "solana-zk-keygen"]:
-        if dep_to_remove in toml_data.get("dependencies", {}):
-            del toml_data["dependencies"][dep_to_remove]
+    # remove unwanted deps except Solana-related ones
+    # (which need to be pinned for deterministic builds)
+    deps_to_remove = ["pickledb", "winreg", "once_cell"]
+    for dep in deps_to_remove:
+        if dep in toml_data.get("dependencies", {}):
+            del toml_data["dependencies"][dep]
 
     for patch_to_remove in ["crossbeam-epoch",]:
         if patch_to_remove in toml_data.get("patch", {}).get("crates-io", {}):
@@ -160,10 +288,23 @@ def main():
             # Assign the entire values object directly
             toml_data[section] = values
 
+    # pin deps from matched lockfile
+    pin_dependencies(toml_data, lockfile_path)
+
     # Write the updated data to the output TOML file
     with open(args.output, "w") as f:
         f.write("# This file is auto generated. See generate_cargo.py\n")
         f.write(toml_data.as_string())
 
+    # Generate lockfile using Cargo
+    try:
+        subprocess.run(["cargo", "generate-lockfile"], cwd=os.path.dirname(args.output), check=True)
+        print(f"Generated Cargo.lock in {os.path.dirname(args.output) or '.'}")
+    except subprocess.CalledProcessError as e:
+        print(f"Error generating Cargo.lock: {e}")
+        return 1
+
+    return 0
+
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
This PR refactors and extends generate_cargo.py to make Agave manifest generation more reliable, deterministic, reproducible, and user-friendly:

- Robust downloading with retries, exponential backoff, and jitter for Cargo.toml/Cargo.lock.
- Unified manifest prep with workspace flattening, metadata cleanup, and path rewrites.
- Dependency pinning: exact versions sourced from Cargo.lock for deterministic builds.
- Smarter CLI with sensible defaults, better help output, and graceful error handling.
- Improved cleanup removing only truly unwanted deps, retaining critical Solana packages.
- Auto-generates the matching Cargo.lock post-build.