### PR TITLE
cargo: pin home dependency when using a local checkout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -1331,9 +1331,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.41"
+version = "1.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
+checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1508,6 +1508,19 @@ dependencies = [
  "anstyle",
  "clap_lex 0.7.6",
  "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2043,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
@@ -2224,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "doc-comment"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "downcast"
@@ -2902,9 +2915,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab69130804d941f8075cfd713bf8848a2c3b3f201a9457a11e6f87e1ab62305"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -2975,7 +2988,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util 0.7.16",
@@ -3571,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -3653,13 +3666,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4510,7 +4523,7 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.5",
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
  "memchr",
 ]
 
@@ -4813,7 +4826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -4823,7 +4836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset 0.5.7",
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -5058,6 +5071,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit 0.23.4",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -5592,9 +5629,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5897,9 +5934,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6204,7 +6241,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
  "itoa",
  "ryu",
  "serde",
@@ -6563,7 +6600,7 @@ dependencies = [
  "bzip2",
  "crossbeam-channel",
  "dashmap",
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
  "io-uring",
  "itertools 0.12.1",
  "libc",
@@ -7013,6 +7050,7 @@ dependencies = [
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
+ "solana-zk-sdk",
  "thiserror 2.0.16",
  "tiny-bip39",
  "uriparse",
@@ -7171,7 +7209,7 @@ dependencies = [
  "dashmap",
  "futures 0.3.31",
  "futures-util",
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
  "indicatif 0.18.0",
  "log",
  "quinn",
@@ -7335,7 +7373,7 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "futures-util",
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
  "log",
  "rand 0.8.5",
  "rayon",
@@ -7975,7 +8013,7 @@ dependencies = [
  "clap 2.34.0",
  "crossbeam-channel",
  "flate2",
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
  "itertools 0.12.1",
  "log",
  "lru",
@@ -9769,7 +9807,7 @@ dependencies = [
  "futures-util",
  "governor",
  "histogram",
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
  "itertools 0.12.1",
  "libc",
  "log",
@@ -10112,7 +10150,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "futures-util",
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
  "indicatif 0.18.0",
  "log",
  "rayon",
@@ -10773,15 +10811,16 @@ dependencies = [
  "hidapi",
  "histogram",
  "hmac 0.12.1",
+ "home",
  "http 1.3.1",
  "humantime",
  "hyper 1.7.0",
  "hyper-proxy",
  "im",
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
  "indicatif 0.18.0",
  "io-uring",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "js-sys",
  "json5",
  "jsonrpc-core",
@@ -10823,9 +10862,10 @@ dependencies = [
  "prio-graph",
  "proc-macro2",
  "proptest",
- "prost 0.13.5",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
  "prost-build 0.13.5",
- "prost-types 0.13.5",
+ "prost-types 0.11.9",
  "protobuf-src",
  "protosol",
  "qstring",
@@ -10833,7 +10873,9 @@ dependencies = [
  "quinn",
  "quinn-proto",
  "quote",
+ "rand 0.7.3",
  "rand 0.9.2",
+ "rand_chacha 0.2.2",
  "rand_chacha 0.9.0",
  "rayon",
  "reed-solomon-erasure",
@@ -12054,7 +12096,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -12068,7 +12110,7 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7211ff1b8f0d3adae1663b7da9ffe396eabe1ca25f0b0bee42b0da29a9ddce93"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.10.0",
  "toml_datetime 0.7.0",
  "toml_parser",
  "winnow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,4 @@
-bench = [
-    { name = "bench_txn", harness = false },
-]
-
+# This file is auto generated. See generate_cargo.py
 [profile.release-with-debug]
 inherits = "release"
 debug = true
@@ -17,12 +14,53 @@ inherits = "release"
 lto = "fat"
 codegen-units = 1
 
+# curve25519-dalek uses the simd backend by default in v4 if possible,
+# which has very slow performance on some platforms with opt-level 0,
+# which is the default for dev and test builds.
+# This slowdown causes certain interactions in the solana-test-validator,
+# such as verifying ZK proofs in transactions, to take much more than 400ms,
+# creating problems in the testing environment.
+# To enable better performance in solana-test-validator during tests and dev builds,
+# we override the opt-level to 3 for the crate.
 [profile.dev.package.curve25519-dalek]
 opt-level = 3
 
-[patch.crates-io.solana-curve25519]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
+[patch.crates-io]
+# for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
+
+# We include the following crates as our dependencies above from crates.io:
+#
+#  * spl-associated-token-account-interface
+#  * spl-instruction-padding
+#  * spl-memo-interface
+#  * spl-pod
+#  * spl-token
+#  * spl-token-2022-interface
+#  * spl-token-metadata-interface
+#
+# They, in turn, depend on a number of crates that we also include directly
+# using `path` specifications.  For example, `spl-token` depends on
+# `solana-program`.  And we explicitly specify `solana-program` above as a local
+# path dependency:
+#
+#     solana-program = { path = "../../sdk/program", version = "=1.16.0" }
+#
+# Unfortunately, Cargo will try to resolve the `spl-token` `solana-program`
+# dependency only using what is available on crates.io.  Crates.io normally
+# contains a previous version of these crates, and we end up with two versions
+# of `solana-program` and `solana-zk-token-sdk` and all of their dependencies in
+# our build tree.
+#
+# If you are developing downstream using non-crates-io solana-program (local or
+# forked repo, or from github rev, eg), duplicate the following patch statements
+# in your Cargo.toml. If you still hit duplicate-type errors with the patch
+# statements in place, run `cargo update -p solana-program` and/or `cargo update
+# -p solana-zk-token-sdk` to remove extraneous versions from your Cargo.lock
+# file.
+#
+# There is a similar override in `programs/sbf/Cargo.toml`.  Please keep both
+# comments and the overrides in sync.
+solana-curve25519 = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"}
 
 [package]
 version = "0.1.0"
@@ -35,19 +73,35 @@ warnings = "deny"
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    "cfg(target_os, values(\"solana\"))",
-    "cfg(feature, values(\"frozen-abi\", \"no-entrypoint\"))",
+    'cfg(target_os, values("solana"))',
+    'cfg(feature, values("frozen-abi", "no-entrypoint"))',
 ]
 
+# Clippy lint configuration that can not be applied in clippy.toml
 [lints.clippy]
 arithmetic_side_effects = "deny"
 default_trait_access = "deny"
 manual_let_else = "deny"
 used_underscore_binding = "deny"
 
+
 [dependencies]
 Inflector = "=0.11.4"
 aes-gcm-siv = "=0.11.1"
+agave-banking-stage-ingress-types = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-cargo-registry = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-geyser-plugin-interface = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-io-uring = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-low-pass-filter = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-precompiles = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-reserved-account-keys = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-syscalls = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-thread-manager = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-transaction-view = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-verified-packet-receiver = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-votor = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+agave-xdp = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 ahash = "=0.8.12"
 anyhow = "=1.0.99"
 aquamarine = "=0.6.0"
@@ -72,9 +126,12 @@ backoff = "=0.4.0"
 base64 = "=0.22.1"
 bencher = "=0.1.5"
 bincode = "=1.3.3"
+bitflags = { version = "=2.9.3" }
 blake3 = "=1.8.2"
+borsh = { version = "=1.5.7", features = ["derive", "unstable__schema"] }
+bs58 = { version = "=0.5.1", default-features = false }
 bv = "=0.11.1"
-byte-unit = "=4.0.19"
+byte-unit = "4.0.19"
 bytemuck = "=1.23.2"
 bytemuck_derive = "=1.10.1"
 bytes = "=1.10.1"
@@ -83,11 +140,14 @@ caps = "=0.5.5"
 cargo_metadata = "=0.15.4"
 cfg-if = "=1.0.3"
 cfg_eval = "=0.1.2"
+chrono = { version = "=0.4.41", default-features = false }
 chrono-humanize = "=0.2.3"
+clap = { version = "=4.5.45", features = ["derive"] }
+# Remove this dependency when procedural macros will support non-inline modules.
 conditional-mod = "=0.1.0"
 console = "=0.16.0"
-console_error_panic_hook = "=0.1.7"
-console_log = "=0.2.2"
+console_error_panic_hook = "0.1.7"
+console_log = "0.2.2"
 const_format = "=0.2.34"
 core_affinity = "=0.5.10"
 criterion = "=0.5.1"
@@ -95,8 +155,11 @@ criterion-stats = "=0.3.0"
 crossbeam-channel = "=0.5.15"
 csv = "=1.3.1"
 ctrlc = "=3.4.7"
+curve25519-dalek = { version = "=4.1.3", features = ["digest", "rand_core"] }
 dashmap = "=5.5.3"
+derivation-path = { version = "=0.2.0", default-features = false }
 derive-where = "=1.6.0"
+derive_more = { version = "=1.0.0", features = ["full"] }
 dialoguer = "=0.10.4"
 digest = "=0.10.7"
 dir-diff = "=0.3.3"
@@ -123,6 +186,7 @@ getrandom = "=0.3.3"
 goauth = "=0.13.1"
 governor = "=0.6.3"
 hex = "=0.4.3"
+hidapi = { version = "=2.6.3", default-features = false }
 histogram = "=0.6.9"
 hmac = "=0.12.1"
 http = "=1.3.1"
@@ -130,10 +194,13 @@ humantime = "=2.2.0"
 hyper = "=1.7.0"
 hyper-proxy = "=0.9.1"
 im = "=15.1.0"
-indexmap = "=2.11.0"
+indexmap = "=2.10.0"
 indicatif = "=0.18.0"
 io-uring = "=0.7.10"
-itertools = "=0.14.0"
+itertools = "=0.13.0"
+jemallocator = { package = "tikv-jemallocator", version = "=0.6.0", features = [
+    "unprefixed_malloc_on_supported_platforms",
+] }
 js-sys = "=0.3.77"
 json5 = "=0.4.1"
 jsonrpc-core = "=18.0.0"
@@ -145,12 +212,17 @@ jsonrpc-pubsub = "=18.0.0"
 lazy-lru = "=0.1.4"
 libc = "=0.2.175"
 libloading = "=0.7.4"
+libsecp256k1 = { version = "=0.6.0", default-features = false, features = [
+    "std",
+    "static-context",
+] }
 light-poseidon = "=0.2.0"
 log = "=0.4.27"
 lru = "=0.7.8"
 lz4 = "=1.28.1"
 memmap2 = "=0.9.8"
 memoffset = "=0.9.1"
+merlin = { version = "=3.0.0", default-features = false }
 min-max-heap = "=1.3.0"
 mockall = "=0.11.4"
 modular-bitfield = "=0.11.2"
@@ -162,6 +234,7 @@ num_cpus = "=1.17.0"
 num_enum = "=0.7.4"
 openssl = "=0.10.73"
 parking_lot = "=0.12.4"
+pbkdf2 = { version = "=0.11.0", default-features = false }
 pem = "=1.1.1"
 percentage = "=0.1.0"
 predicates = "=3.1.3"
@@ -170,30 +243,36 @@ pretty_assertions = "=1.4.1"
 prio-graph = "=0.3.0"
 proc-macro2 = "=1.0.101"
 proptest = "=1.7.0"
-prost = "=0.13.5"
-prost-build = "=0.13.5"
-prost-types = "=0.13.5"
+prost = "=0.11.9"
+prost-build = "=0.11.9"
+prost-types = "=0.11.9"
 protobuf-src = "=1.1.0"
 qstring = "=0.7.2"
+qualifier_attr = { version = "=0.2.2", default-features = false }
 quinn = "=0.11.8"
 quinn-proto = "=0.11.12"
 quote = "=1.0.40"
 rand = "=0.9.2"
+rand0-7 = { package = "rand", version = "0.7" }
 rand_chacha = "=0.9.0"
+rand_chacha0-2 = { package = "rand_chacha", version = "0.2.2" }
 rayon = "=1.11.0"
 reed-solomon-erasure = "=6.0.0"
-regex = "=1.11.2"
+regex = "=1.11.1"
+reqwest = { version = "=0.12.23", default-features = false }
 reqwest-middleware = "=0.4.2"
 rolling-file = "=0.2.0"
 rpassword = "=7.4.0"
+rustls = { version = "=0.23.31", features = ["std"], default-features = false }
 scopeguard = "=1.2.0"
 semver = "=1.0.26"
 seqlock = "=0.2.0"
-serde = "=1.0.219"
+serde = "=1.0.219" # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde-big-array = "=0.5.1"
 serde_bytes = "=0.11.17"
-serde_derive = "=1.0.219"
+serde_derive = "=1.0.219" # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_json = "=1.0.143"
+serde_with = { version = "=3.14.0", default-features = false }
 serde_yaml = "=0.9.34"
 serial_test = "=2.0.0"
 sha2 = "=0.10.9"
@@ -207,36 +286,69 @@ smpl_jwt = "=0.7.1"
 socket2 = "=0.6.0"
 soketto = "=0.7.1"
 solana-account = "=3.0.0"
+solana-account-decoder = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-account-decoder-client-types = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-account-info = "=3.0.0"
+solana-accounts-db = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-address-lookup-table-interface = "=3.0.0"
 solana-atomic-u64 = "=3.0.0"
+solana-banks-client = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-banks-interface = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-banks-server = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-bench-tps = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-big-mod-exp = "=3.0.0"
 solana-bincode = "=3.0.0"
 solana-blake3-hasher = "=3.0.0"
+solana-bloom = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-bn254 = "=3.0.0"
 solana-borsh = "=3.0.0"
+solana-bpf-loader-program = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-bucket-map = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-builtins = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-builtins-default-costs = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-clap-utils = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-clap-v3-utils = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-cli = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-cli-config = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-cli-output = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-client = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-client-traits = "=3.0.0"
 solana-clock = "=3.0.0"
 solana-cluster-type = "=3.0.0"
 solana-commitment-config = "=3.0.0"
+solana-compute-budget = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-compute-budget-instruction = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-compute-budget-interface = "=3.0.0"
+solana-compute-budget-program = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-config-interface = "=2.0.0"
+solana-connection-cache = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-core = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-cost-model = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-cpi = "=3.0.0"
+solana-curve25519 = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-define-syscall = "=3.0.0"
 solana-derivation-path = "=3.0.0"
+solana-download-utils = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-ed25519-program = "=3.0.0"
+solana-entry = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-epoch-info = "=3.0.0"
 solana-epoch-rewards = "=3.0.0"
 solana-epoch-rewards-hasher = "=3.0.0"
 solana-epoch-schedule = "=3.0.0"
 solana-example-mocks = "=3.0.0"
+solana-faucet = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-feature-gate-interface = "=3.0.0"
+solana-fee = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-fee-calculator = "=3.0.0"
 solana-fee-structure = "=3.0.0"
 solana-file-download = "=3.0.0"
 solana-frozen-abi = "=3.0.0"
 solana-frozen-abi-macro = "=3.0.0"
+solana-genesis = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-genesis-config = "=3.0.0"
+solana-genesis-utils = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-geyser-plugin-manager = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-gossip = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-hard-forks = "=3.0.0"
 solana-hash = "=3.0.0"
 solana-inflation = "=3.0.0"
@@ -246,56 +358,121 @@ solana-instructions-sysvar = "=3.0.0"
 solana-keccak-hasher = "=3.0.0"
 solana-keypair = "=3.0.0"
 solana-last-restart-slot = "=3.0.0"
+solana-lattice-hash = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-ledger = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-loader-v2-interface = "=3.0.0"
 solana-loader-v3-interface = "=6.1.0"
 solana-loader-v4-interface = "=3.1.0"
+solana-loader-v4-program = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-local-cluster = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-logger = "=3.0.0"
+solana-measure = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-merkle-tree = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-message = "=3.0.0"
+solana-metrics = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-msg = "=3.0.0"
 solana-native-token = "=3.0.0"
+solana-net-utils = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-nohash-hasher = "=0.2.1"
 solana-nonce = "=3.0.0"
 solana-nonce-account = "=3.0.0"
+solana-notifier = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-offchain-message = "=3.0.0"
 solana-packet = "=3.0.0"
+solana-perf = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-poh = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-poh-config = "=3.0.0"
+solana-poseidon = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-precompile-error = "=3.0.0"
 solana-presigner = "=3.0.0"
+solana-program = { version = "=3.0.0", default-features = false }
 solana-program-entrypoint = "=3.1.0"
 solana-program-error = "=3.0.0"
 solana-program-memory = "=3.0.0"
 solana-program-option = "=3.0.0"
 solana-program-pack = "=3.0.0"
+solana-program-runtime = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-program-test = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-pubkey = { version = "=3.0.0", default-features = false }
+solana-pubsub-client = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-quic-client = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-quic-definitions = "=3.0.0"
+solana-rayon-threadlimit = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-remote-wallet = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-rent = "=3.0.0"
 solana-reward-info = "=3.0.0"
+solana-rpc = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-rpc-client = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-rpc-client-api = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-rpc-client-nonce-utils = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-rpc-client-types = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-runtime = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-runtime-transaction = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-sanitize = "=3.0.0"
+solana-sbpf = { git = "https://github.com/firedancer-io/sbpf", branch = "sbpf-v0.12.2-patches", default-features = false, version = "=0.12.2"}
 solana-sdk-ids = "=3.0.0"
 solana-secp256k1-program = "=3.0.0"
 solana-secp256k1-recover = "=3.0.0"
 solana-secp256r1-program = "=3.0.0"
 solana-seed-derivable = "=3.0.0"
 solana-seed-phrase = "=3.0.0"
+solana-send-transaction-service = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-serde = "=3.0.0"
 solana-serde-varint = "=3.0.0"
 solana-serialize-utils = "=3.0.0"
 solana-sha256-hasher = "=3.0.0"
 solana-short-vec = "=3.0.0"
 solana-shred-version = "=3.0.0"
+solana-signature = { version = "=3.1.0", default-features = false }
 solana-signer = "=3.0.0"
 solana-slot-hashes = "=3.0.0"
 solana-slot-history = "=3.0.0"
 solana-stable-layout = "=3.0.0"
+solana-stake-interface = { version = "=2.0.1" }
+solana-stake-program = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-storage-bigtable = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-storage-proto = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-streamer = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-svm = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-svm-callback = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-svm-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-svm-log-collector = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-svm-measure = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-svm-timings = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-svm-transaction = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-svm-type-overrides = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-system-interface = "=2.0.0"
+solana-system-program = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-system-transaction = "=3.0.0"
 solana-sysvar = "=3.0.0"
 solana-sysvar-id = "=3.0.0"
+solana-test-validator = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-time-utils = "=3.0.0"
+solana-tls-utils = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-tps-client = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-tpu-client = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-tpu-client-next = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-transaction = "=3.0.0"
+solana-transaction-context = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-transaction-error = "=3.0.0"
+solana-transaction-metrics-tracker = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-transaction-status = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-transaction-status-client-types = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-turbine = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-udp-client = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-unified-scheduler-logic = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-unified-scheduler-pool = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-validator-exit = "=3.0.0"
+solana-version = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-vote = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-vote-interface = "=3.0.0"
+solana-vote-program = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-wen-restart = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-zk-elgamal-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-zk-keygen = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 solana-zk-sdk = "=4.0.0"
+solana-zk-token-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
+solana-zk-token-sdk = {git = "https://github.com/firedancer-io/agave", rev = "5ca585786b6e0f95914c0866c7e40a257290f61c", version = "=3.0.3"}
 spl-associated-token-account-interface = "=2.0.0"
 spl-generic-token = "=2.0.1"
 spl-memo-interface = "=2.0.0"
@@ -337,661 +514,29 @@ trees = "=0.4.2"
 tungstenite = "=0.20.1"
 unwrap_none = "=0.1.2"
 uriparse = "=0.6.4"
-url = "=2.5.7"
+url = "=2.5.6"
 vec_extract_if_polyfill = "=0.1.0"
 wasm-bindgen = "=0.2.100"
 winapi = "=0.3.9"
 x509-parser = "=0.14.0"
+zeroize = { version = "=1.8.1", default-features = false }
 zstd = "=0.13.3"
+protosol = {git = "https://github.com/firedancer-io/protosol", tag = "v1.0.5"}
+solfuzz-agave-macro = { path = "macro" }
 once_cell = "=1.21.3"
 lazy_static = "=1.5.0"
-protosol = {git = "https://github.com/firedancer-io/protosol", tag = "v1.0.5"}
+home = "=0.5.11"
 
-[dependencies.agave-banking-stage-ingress-types]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
+[[bench]]
+name = "bench_txn"
+harness = false
 
-[dependencies.agave-feature-set]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.agave-geyser-plugin-interface]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.agave-io-uring]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.agave-low-pass-filter]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.agave-precompiles]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.agave-reserved-account-keys]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.agave-syscalls]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.agave-thread-manager]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.agave-transaction-view]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.agave-verified-packet-receiver]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.agave-votor]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.agave-xdp]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.bitflags]
-version = "=2.9.3"
-
-[dependencies.borsh]
-version = "=1.5.7"
-features = [
-    "derive",
-    "unstable__schema",
-]
-
-[dependencies.bs58]
-version = "=0.5.1"
-default-features = false
-
-[dependencies.chrono]
-version = "=0.4.41"
-default-features = false
-
-[dependencies.clap]
-version = "=4.5.45"
-features = [
-    "derive",
-]
-
-[dependencies.curve25519-dalek]
-version = "=4.1.3"
-features = [
-    "digest",
-    "rand_core",
-]
-
-[dependencies.derivation-path]
-version = "=0.2.0"
-default-features = false
-
-[dependencies.derive_more]
-version = "=1.0.0"
-features = [
-    "full",
-]
-
-[dependencies.hidapi]
-version = "=2.6.3"
-default-features = false
-
-[dependencies.jemallocator]
-package = "tikv-jemallocator"
-version = "=0.6.0"
-features = [
-    "unprefixed_malloc_on_supported_platforms",
-]
-
-[dependencies.libsecp256k1]
-version = "=0.6.0"
-default-features = false
-features = [
-    "std",
-    "static-context",
-]
-
-[dependencies.merlin]
-version = "=3.0.0"
-default-features = false
-
-[dependencies.pbkdf2]
-version = "=0.11.0"
-default-features = false
-
-[dependencies.qualifier_attr]
-version = "=0.2.2"
-default-features = false
-
-[dependencies.reqwest]
-version = "=0.12.23"
-default-features = false
-
-[dependencies.rustls]
-version = "=0.23.31"
-features = [
-    "std",
-]
-default-features = false
-
-[dependencies.serde_with]
-version = "=3.14.0"
-default-features = false
-
-[dependencies.solana-account-decoder]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-account-decoder-client-types]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-accounts-db]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-banks-client]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-banks-interface]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-banks-server]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-bench-tps]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-bloom]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-bpf-loader-program]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-bucket-map]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-builtins]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-builtins-default-costs]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-clap-utils]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-clap-v3-utils]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-cli]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-cli-config]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-cli-output]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-client]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-compute-budget]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-compute-budget-instruction]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-compute-budget-program]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-connection-cache]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-core]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-cost-model]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-curve25519]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-download-utils]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-entry]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-faucet]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-fee]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-genesis]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-genesis-utils]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-geyser-plugin-manager]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-gossip]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-lattice-hash]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-ledger]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-loader-v4-program]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-local-cluster]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-measure]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-merkle-tree]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-metrics]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-net-utils]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-notifier]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-perf]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-poh]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-poseidon]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-program-runtime]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-program-test]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-pubkey]
-version = "=3.0.0"
-default-features = false
-
-[dependencies.solana-pubsub-client]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-quic-client]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-rayon-threadlimit]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-remote-wallet]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-rpc]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-rpc-client]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-rpc-client-api]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-rpc-client-nonce-utils]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-rpc-client-types]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-runtime]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-runtime-transaction]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-sbpf]
-git = "https://github.com/firedancer-io/sbpf"
-branch = "sbpf-v0.12.2-patches"
-default-features = false
-version = "=0.12.2"
-
-[dependencies.solana-send-transaction-service]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-signature]
-version = "=3.1.0"
-default-features = false
-
-[dependencies.solana-stake-interface]
-version = "=2.0.1"
-
-[dependencies.solana-stake-program]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-storage-bigtable]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-storage-proto]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-streamer]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-svm]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-svm-callback]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-svm-feature-set]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-svm-log-collector]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-svm-measure]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-svm-timings]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-svm-transaction]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-svm-type-overrides]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-system-program]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-test-validator]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-tls-utils]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-tps-client]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-tpu-client]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-tpu-client-next]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-transaction-context]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-transaction-metrics-tracker]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-transaction-status]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-transaction-status-client-types]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-turbine]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-udp-client]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-unified-scheduler-logic]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-unified-scheduler-pool]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-version]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-vote]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-vote-program]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-wen-restart]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-zk-elgamal-proof-program]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-zk-token-proof-program]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.solana-zk-token-sdk]
-git = "https://github.com/firedancer-io/agave"
-rev = "5ca585786b6e0f95914c0866c7e40a257290f61c"
-version = "=3.0.3"
-
-[dependencies.zeroize]
-version = "=1.8.1"
-default-features = false
-
-[dependencies.solfuzz-agave-macro]
-path = "macro"
-version = "=0.1.0"
 
 [lib]
-crate-type = [
-    "cdylib",
-    "rlib",
-]
+crate-type = ["cdylib", "rlib"]
 
 [build-dependencies]
-prost-build = "=0.13.5"
+prost-build = "0.13.1"
 
 [features]
 core-bpf = []

--- a/solfuzz_agave.toml
+++ b/solfuzz_agave.toml
@@ -12,6 +12,7 @@ clap = { version = "4.5.2", features = ["derive"] }
 solfuzz-agave-macro = { path = "macro" }
 once_cell = "1.21.3"
 lazy_static = "1.5.0"
+home = "0.5.11"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
home gets bumped to a version which doesn't support rustc 1.86.