### PR TITLE
set artifacts to be built with nightly-2025-10-30

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -18,8 +18,12 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.86.0
+      # TODO: change back to stable once rust releases the coverage fix
+      # - uses: dtolnay/rust-toolchain@1.86.0
+      - uses: actions-rs/toolchain@v1
         with:
+          toolchain: nightly-2025-10-30
+          override: true
           components: "clippy, rustfmt"
       - uses: Swatinem/rust-cache@v2
         with:

--- a/src/utils/fd_hash.rs
+++ b/src/utils/fd_hash.rs
@@ -5,12 +5,6 @@ const C3: u64 = 1609587929392839161;
 const C4: u64 = 9650029242287828579;
 const C5: u64 = 2870177450012600261;
 
-#[inline(always)]
-#[allow(clippy::arithmetic_side_effects)]
-fn rotate_left(x: u64, r: u32) -> u64 {
-    (x << r) | (x >> (64 - r))
-}
-
 /// Rust port of Firedancer's fd_hash
 /// https://github.com/firedancer-io/firedancer/blob/main/src/util/fd_hash.c
 pub fn fd_hash(seed: u64, buf: &[u8]) -> u64 {
@@ -32,32 +26,33 @@ pub fn fd_hash(seed: u64, buf: &[u8]) -> u64 {
             let p2 = u64::from_le_bytes(p[16..24].try_into().unwrap());
             let p3 = u64::from_le_bytes(p[24..32].try_into().unwrap());
             w = w.wrapping_add(p0.wrapping_mul(C2));
-            w = rotate_left(w, 31);
+            w = w.rotate_left(31);
             w = w.wrapping_mul(C1);
 
             x = x.wrapping_add(p1.wrapping_mul(C2));
-            x = rotate_left(x, 31);
+            x = x.rotate_left(31);
             x = x.wrapping_mul(C1);
 
             y = y.wrapping_add(p2.wrapping_mul(C2));
-            y = rotate_left(y, 31);
+            y = y.rotate_left(31);
             y = y.wrapping_mul(C1);
 
             z = z.wrapping_add(p3.wrapping_mul(C2));
-            z = rotate_left(z, 31);
+            z = z.rotate_left(31);
             z = z.wrapping_mul(C1);
 
             p = &p[32..];
         }
 
-        h = rotate_left(w, 1)
-            .wrapping_add(rotate_left(x, 7))
-            .wrapping_add(rotate_left(y, 12))
-            .wrapping_add(rotate_left(z, 18));
+        h = w
+            .rotate_left(1)
+            .wrapping_add(x.rotate_left(7))
+            .wrapping_add(y.rotate_left(12))
+            .wrapping_add(z.rotate_left(18));
 
         for v in [w, x, y, z] {
             let mut vv = v.wrapping_mul(C2);
-            vv = rotate_left(vv, 31);
+            vv = vv.rotate_left(31);
             vv = vv.wrapping_mul(C1);
             h ^= vv;
             h = h.wrapping_mul(C1).wrapping_add(C4);
@@ -69,10 +64,10 @@ pub fn fd_hash(seed: u64, buf: &[u8]) -> u64 {
     while p.len() >= 8 {
         let w = u64::from_le_bytes(p[0..8].try_into().unwrap());
         let mut ww = w.wrapping_mul(C2);
-        ww = rotate_left(ww, 31);
+        ww = ww.rotate_left(31);
         ww = ww.wrapping_mul(C1);
         h ^= ww;
-        h = rotate_left(h, 27).wrapping_mul(C1).wrapping_add(C4);
+        h = h.rotate_left(27).wrapping_mul(C1).wrapping_add(C4);
         p = &p[8..];
     }
 
@@ -80,14 +75,14 @@ pub fn fd_hash(seed: u64, buf: &[u8]) -> u64 {
         let w = u32::from_le_bytes(p[0..4].try_into().unwrap()) as u64;
         let ww = w.wrapping_mul(C1);
         h ^= ww;
-        h = rotate_left(h, 23).wrapping_mul(C2).wrapping_add(C3);
+        h = h.rotate_left(23).wrapping_mul(C2).wrapping_add(C3);
         p = &p[4..];
     }
 
     for &byte in p {
         let w = (byte as u64).wrapping_mul(C5);
         h ^= w;
-        h = rotate_left(h, 11).wrapping_mul(C1);
+        h = h.rotate_left(11).wrapping_mul(C1);
     }
 
     // Final avalanche

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -26,8 +26,8 @@ pub const fn feature_u64(feature: &Pubkey) -> u64 {
 lazy_static! {
     static ref INDEXED_FEATURES: AHashMap<u64, Pubkey> = {
         FEATURE_NAMES
-            .iter()
-            .map(|(pubkey, _)| (feature_u64(pubkey), *pubkey))
+            .keys()
+            .map(|pubkey| (feature_u64(pubkey), *pubkey))
             .collect()
     };
 }


### PR DESCRIPTION
I had to do some changes due to clippy failing on nightly:

```

error: there is no need to manually implement bit rotation
  --> src/utils/fd_hash.rs:11:5
   |
11 |     (x << r) | (x >> (64 - r))
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: this expression can be rewritten as: `x.rotate_left(r)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_rotate
   = note: `-D clippy::manual-rotate` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::manual_rotate)]`

error: iterating on a map's keys
  --> src/utils/mod.rs:28:9
   |
28 | /         FEATURE_NAMES
29 | |             .iter()
30 | |             .map(|(pubkey, _)| (feature_u64(pubkey), *pubkey))
   | |______________________________________________________________^ help: try: `FEATURE_NAMES.keys().map(|pubkey| (feature_u64(pubkey), *pubkey))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_kv_map
   = note: `-D clippy::iter-kv-map` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::iter_kv_map)]`
```
