### PR TITLE
Package pinning for Agave v3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 name = "agave-banking-stage-ingress-types"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -78,7 +78,7 @@ dependencies = [
 [[package]]
 name = "agave-cargo-registry"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-logger",
  "clap 2.34.0",
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 name = "agave-feature-set"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule",
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "agave-fs"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -136,7 +136,7 @@ dependencies = [
 [[package]]
 name = "agave-geyser-plugin-interface"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "log",
  "solana-clock",
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "agave-io-uring"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "io-uring",
  "libc",
@@ -162,7 +162,7 @@ dependencies = [
 [[package]]
 name = "agave-logger"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "env_logger",
  "libc",
@@ -173,7 +173,7 @@ dependencies = [
 [[package]]
 name = "agave-precompiles"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -194,7 +194,7 @@ dependencies = [
 [[package]]
 name = "agave-reserved-account-keys"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey 3.0.0",
@@ -204,12 +204,12 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 
 [[package]]
 name = "agave-scheduling-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-scheduler-bindings",
  "agave-transaction-view",
@@ -226,7 +226,7 @@ dependencies = [
 [[package]]
 name = "agave-snapshots"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-fs",
  "bincode",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "agave-syscalls"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "bincode",
  "libsecp256k1",
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "agave-thread-manager"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "affinity",
  "anyhow",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "agave-transaction-view"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "solana-hash 3.0.0",
  "solana-message",
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "agave-verified-packet-receiver"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "solana-perf",
  "solana-streamer",
@@ -339,7 +339,7 @@ dependencies = [
 [[package]]
 name = "agave-votor"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-logger",
  "agave-votor-messages",
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "agave-votor-messages"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-logger",
  "serde",
@@ -403,7 +403,7 @@ dependencies = [
 [[package]]
 name = "agave-xdp"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-xdp-ebpf",
  "aya",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "agave-xdp-ebpf"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "aya",
  "aya-ebpf",
@@ -568,7 +568,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -700,7 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -726,7 +726,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -801,7 +801,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -957,7 +957,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -968,7 +968,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1033,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
 dependencies = [
  "axum-core 0.5.5",
  "bytes",
@@ -1044,7 +1044,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "aya"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
+checksum = "7127cbe933572dfabb7a87d2c740f5b720c3e19b4d2b8c99a262ffa35c8761ff"
 dependencies = [
  "assert_matches",
  "aya-obj",
@@ -1115,6 +1115,16 @@ dependencies = [
  "object",
  "once_cell",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "aya-build"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c92c523541cbf5e3a94c7a6ff4068a4d9537f98a2eeb136461c0537ded8c1"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.19.2",
 ]
 
 [[package]]
@@ -1153,7 +1163,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1250,7 +1260,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1394,7 +1404,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1493,7 +1503,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1504,9 +1514,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
  "serde",
 ]
@@ -1579,6 +1589,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,9 +1619,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1646,7 +1670,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1752,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1762,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1781,7 +1805,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2022,7 +2046,7 @@ dependencies = [
  "anes",
  "cast 0.3.0",
  "ciborium",
- "clap 4.5.51",
+ "clap 4.5.53",
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
@@ -2215,7 +2239,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2239,7 +2263,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2250,7 +2274,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2332,7 +2356,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2345,7 +2369,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2366,7 +2390,7 @@ dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "unicode-xid",
 ]
 
@@ -2465,7 +2489,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2488,7 +2512,7 @@ checksum = "a6cbae11b3de8fce2a456e8ea3dada226b35fe791f0dc1d360c0941f0bb681f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2573,6 +2597,18 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek-bip32"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2be62a4061b872c8c0873ee4fc6f101ce7b889d039f019c5fa2af471a59908"
+dependencies = [
+ "derivation-path",
+ "ed25519-dalek 1.0.1",
+ "hmac 0.12.1",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "ed25519-dalek-bip32"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b49a684b133c4980d7ee783936af771516011c8cd15f429dbda77245e282f03"
@@ -2604,7 +2640,7 @@ dependencies = [
  "enum-ordinalize 4.3.2",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2664,7 +2700,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2677,7 +2713,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2697,7 +2733,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2846,9 +2882,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "five8"
@@ -2920,15 +2956,6 @@ name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
@@ -3056,7 +3083,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3545,9 +3572,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3604,7 +3631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-util",
  "rustls 0.23.35",
  "rustls-native-certs",
@@ -3642,9 +3669,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3653,7 +3680,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding 2.3.2",
@@ -3884,9 +3911,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade6dfcba0dfb62ad59e59e7241ec8912af34fd29e0e743e3db992bd278e8b65"
+checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
  "console 0.16.1",
  "portable-atomic",
@@ -4020,7 +4047,7 @@ checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4585,7 +4612,7 @@ checksum = "8462d3cc74eaf4194f6c0bd7b18c6f3fa6293297f4bdb60fe4c4b022ea366e12"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4728,7 +4755,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4801,7 +4828,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4872,9 +4899,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.74"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if 1.0.4",
@@ -4893,7 +4920,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5117,7 +5144,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5167,7 +5194,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5284,7 +5311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
- "float-cmp 0.9.0",
+ "float-cmp",
  "itertools 0.10.5",
  "normalize-line-endings",
  "predicates-core",
@@ -5299,10 +5326,7 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
- "float-cmp 0.10.0",
- "normalize-line-endings",
  "predicates-core",
- "regex",
 ]
 
 [[package]]
@@ -5354,7 +5378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5514,7 +5538,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.108",
+ "syn 2.0.110",
  "tempfile",
 ]
 
@@ -5541,7 +5565,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5599,7 +5623,7 @@ checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5682,9 +5706,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -6037,7 +6061,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
@@ -6499,7 +6523,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6549,9 +6573,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.15.1"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa66c845eee442168b2c8134fec70ac50dc20e760769c8ba0ad1319ca1959b04"
+checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
 dependencies = [
  "serde_core",
  "serde_with_macros",
@@ -6559,14 +6583,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.15.1"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91a903660542fced4e99881aa481bdbaec1634568ee02e0b8bd57c64cb38955"
+checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6604,7 +6628,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6868,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -6909,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder-client-types"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6936,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "solana-accounts-db"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-fs",
  "ahash 0.8.12",
@@ -7058,7 +7082,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "borsh",
  "futures 0.3.31",
@@ -7085,7 +7109,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-interface"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "serde",
  "solana-account",
@@ -7104,7 +7128,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-server"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7166,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "solana-bloom"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "bv",
  "fnv",
@@ -7227,7 +7251,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -7255,7 +7279,7 @@ dependencies = [
 [[package]]
 name = "solana-bucket-map"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "bv",
  "bytemuck",
@@ -7273,7 +7297,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -7293,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins-default-costs"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -7311,7 +7335,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -7340,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-v3-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "chrono",
  "clap 3.2.25",
@@ -7369,7 +7393,7 @@ dependencies = [
 [[package]]
 name = "solana-cli"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -7455,7 +7479,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-config"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "dirs-next",
  "serde",
@@ -7468,7 +7492,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-output"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -7477,7 +7501,7 @@ dependencies = [
  "clap 2.34.0",
  "console 0.16.1",
  "humantime",
- "indicatif 0.18.2",
+ "indicatif 0.18.3",
  "pretty-hex",
  "semver",
  "serde",
@@ -7509,7 +7533,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7517,7 +7541,7 @@ dependencies = [
  "futures 0.3.31",
  "futures-util",
  "indexmap 2.12.0",
- "indicatif 0.18.2",
+ "indicatif 0.18.3",
  "log",
  "quinn",
  "rayon",
@@ -7611,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -7620,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-instruction"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -7651,7 +7675,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -7676,7 +7700,7 @@ dependencies = [
 [[package]]
 name = "solana-connection-cache"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7698,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "solana-core"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -7842,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "solana-cost-model"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -7882,9 +7906,8 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2ca224d51d8a1cc20f221706968d8f851586e6b05937cb518bedc156596dee"
+version = "3.1.0-beta.0"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -7896,8 +7919,9 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134f67bd3031223df4aba035c503e4d14acacfc4cf19af10d10ec9c2605bb84f"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -7942,7 +7966,7 @@ dependencies = [
 [[package]]
 name = "solana-download-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -7967,7 +7991,7 @@ dependencies = [
 [[package]]
 name = "solana-entry"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -8076,7 +8100,7 @@ dependencies = [
 [[package]]
 name = "solana-faucet"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -8127,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "solana-fee"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -8197,13 +8221,13 @@ checksum = "38e4bb0f5232668866a7f6f5cbc3222bbd9eebbff6afe392e3394498e8c9b1fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "solana-genesis"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8281,7 +8305,7 @@ dependencies = [
 [[package]]
 name = "solana-genesis-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -8295,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "solana-geyser-plugin-manager"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -8326,7 +8350,7 @@ dependencies = [
 [[package]]
 name = "solana-gossip"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8501,7 +8525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "952ed9074c12edd2060cb09c2a8c664303f4ab7f7056a407ac37dd1da7bdaa3e"
 dependencies = [
  "ed25519-dalek 2.2.0",
- "ed25519-dalek-bip32",
+ "ed25519-dalek-bip32 0.3.0",
  "five8",
  "rand 0.8.5",
  "solana-derivation-path",
@@ -8528,7 +8552,7 @@ dependencies = [
 [[package]]
 name = "solana-lattice-hash"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -8539,7 +8563,7 @@ dependencies = [
 [[package]]
 name = "solana-ledger"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -8683,7 +8707,7 @@ dependencies = [
 [[package]]
 name = "solana-loader-v4-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "log",
  "solana-account",
@@ -8706,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "solana-local-cluster"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-logger",
  "agave-snapshots",
@@ -8770,12 +8794,12 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 
 [[package]]
 name = "solana-merkle-tree"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "fast-math",
  "solana-hash 3.0.0",
@@ -8805,7 +8829,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -8835,7 +8859,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 [[package]]
 name = "solana-net-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8889,7 +8913,7 @@ dependencies = [
 [[package]]
 name = "solana-notifier"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "log",
  "reqwest 0.12.24",
@@ -8930,7 +8954,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -8970,7 +8994,7 @@ dependencies = [
 [[package]]
 name = "solana-poh"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "arc-swap",
  "core_affinity",
@@ -9004,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "solana-poseidon"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-bn254 0.5.0",
@@ -9083,7 +9107,7 @@ dependencies = [
 [[package]]
 name = "solana-program-binaries"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "bincode",
  "serde",
@@ -9146,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9190,7 +9214,7 @@ dependencies = [
 [[package]]
 name = "solana-program-test"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -9283,7 +9307,7 @@ dependencies = [
 [[package]]
 name = "solana-pubsub-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -9308,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "solana-quic-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -9346,7 +9370,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "log",
  "num_cpus",
@@ -9355,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "console 0.16.1",
  "dialoguer",
@@ -9401,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -9487,14 +9511,14 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bincode",
  "bs58",
  "futures 0.3.31",
- "indicatif 0.18.2",
+ "indicatif 0.18.3",
  "log",
  "reqwest 0.12.24",
  "reqwest-middleware",
@@ -9526,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-api"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -9546,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-nonce-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "clap 2.34.0",
  "solana-account",
@@ -9564,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-types"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -9590,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "agave-fs",
@@ -9727,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime-transaction"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -9800,7 +9824,7 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -9863,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "solana-send-transaction-service"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -10053,7 +10077,7 @@ dependencies = [
 [[package]]
 name = "solana-stake-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -10075,7 +10099,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-bigtable"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -10115,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-proto"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "bincode",
  "bs58",
@@ -10140,7 +10164,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -10187,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -10230,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-callback"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -10241,12 +10265,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-feature-set"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 
 [[package]]
 name = "solana-svm-log-collector"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "log",
 ]
@@ -10254,12 +10278,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-measure"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 
 [[package]]
 name = "solana-svm-test-harness"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -10292,7 +10316,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-timings"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -10302,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-transaction"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "solana-hash 3.0.0",
  "solana-message",
@@ -10315,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-type-overrides"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -10338,7 +10362,7 @@ dependencies = [
 [[package]]
 name = "solana-system-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "bincode",
  "log",
@@ -10422,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "solana-test-validator"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -10479,7 +10503,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 [[package]]
 name = "solana-tls-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "rustls 0.23.35",
  "solana-keypair",
@@ -10491,7 +10515,7 @@ dependencies = [
 [[package]]
 name = "solana-tps-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "log",
  "solana-account",
@@ -10521,13 +10545,13 @@ dependencies = [
 [[package]]
 name = "solana-tpu-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "async-trait",
  "bincode",
  "futures-util",
  "indexmap 2.12.0",
- "indicatif 0.18.2",
+ "indicatif 0.18.3",
  "log",
  "rayon",
  "solana-client-traits",
@@ -10554,7 +10578,7 @@ dependencies = [
 [[package]]
 name = "solana-tpu-client-next"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "async-trait",
  "log",
@@ -10602,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -10631,7 +10655,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-metrics-tracker"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10646,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -10688,7 +10712,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status-client-types"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10711,7 +10735,7 @@ dependencies = [
 [[package]]
 name = "solana-turbine"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "agave-votor",
@@ -10766,7 +10790,7 @@ dependencies = [
 [[package]]
 name = "solana-udp-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -10781,7 +10805,7 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-logic"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "assert_matches",
  "solana-pubkey 3.0.0",
@@ -10794,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-pool"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -10835,7 +10859,7 @@ checksum = "c5d2face763df5afeaa9509b9019968860e69cc1531ec8b4a2e6c7b702204d5a"
 [[package]]
 name = "solana-version"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -10848,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "solana-vote"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "bincode",
  "itertools 0.12.1",
@@ -10902,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -10934,7 +10958,7 @@ dependencies = [
 [[package]]
 name = "solana-wen-restart"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-snapshots",
  "anyhow",
@@ -10963,7 +10987,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-elgamal-proof-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -11016,7 +11040,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-proof-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -11032,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-sdk"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=69f8b729eba4a889304cd101109031f245593f7d#69f8b729eba4a889304cd101109031f245593f7d"
+source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -11103,9 +11127,14 @@ dependencies = [
  "async-lock",
  "async-trait",
  "atty",
- "axum 0.8.6",
+ "axum 0.8.7",
  "aya",
+ "aya-build",
  "aya-ebpf",
+ "aya-ebpf-bindings",
+ "aya-ebpf-cty",
+ "aya-ebpf-macros",
+ "aya-obj",
  "backoff",
  "base64 0.22.1",
  "bencher",
@@ -11122,12 +11151,12 @@ dependencies = [
  "bytes",
  "bzip2",
  "caps",
- "cargo_metadata",
+ "cargo_metadata 0.15.4",
  "cfg-if 1.0.4",
  "cfg_eval",
  "chrono",
  "chrono-humanize",
- "clap 4.5.51",
+ "clap 4.5.53",
  "console 0.16.1",
  "console_error_panic_hook",
  "console_log",
@@ -11150,8 +11179,8 @@ dependencies = [
  "dlopen2",
  "dyn-clone",
  "eager",
- "ed25519-dalek 2.2.0",
- "ed25519-dalek-bip32",
+ "ed25519-dalek 1.0.1",
+ "ed25519-dalek-bip32 0.2.0",
  "enum-iterator",
  "env_logger",
  "fast-math",
@@ -11174,15 +11203,15 @@ dependencies = [
  "histogram",
  "hmac 0.12.1",
  "home",
- "http 1.3.1",
+ "http 0.2.12",
  "humantime",
- "hyper 1.7.0",
+ "hyper 0.14.32",
  "hyper-proxy",
  "im",
  "indexmap 2.12.0",
- "indicatif 0.18.2",
+ "indicatif 0.18.3",
  "io-uring",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "js-sys",
  "json5",
  "jsonrpc-core",
@@ -11219,7 +11248,7 @@ dependencies = [
  "pbkdf2 0.12.2",
  "pem",
  "percentage",
- "predicates 3.1.3",
+ "predicates 2.1.5",
  "pretty-hex",
  "pretty_assertions",
  "prio-graph",
@@ -11237,9 +11266,9 @@ dependencies = [
  "quinn-proto",
  "quote",
  "rand 0.7.3",
- "rand 0.9.2",
+ "rand 0.8.5",
  "rand_chacha 0.2.2",
- "rand_chacha 0.9.0",
+ "rand_chacha 0.3.1",
  "rayon",
  "reed-solomon-erasure",
  "regex",
@@ -11476,7 +11505,7 @@ dependencies = [
  "strum_macros",
  "subtle",
  "symlink",
- "syn 2.0.108",
+ "syn 2.0.110",
  "sys-info",
  "sysctl",
  "systemstat",
@@ -11580,7 +11609,7 @@ checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
 dependencies = [
  "quote",
  "spl-discriminator-syn",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -11592,7 +11621,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.9",
- "syn 2.0.108",
+ "syn 2.0.110",
  "thiserror 1.0.69",
 ]
 
@@ -11671,7 +11700,7 @@ checksum = "879a9ebad0d77383d3ea71e7de50503554961ff0f4ef6cbca39ad126e6f6da3a"
 dependencies = [
  "bytemuck",
  "solana-account-info",
- "solana-curve25519 3.0.10",
+ "solana-curve25519 3.1.1",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-msg",
@@ -11857,9 +11886,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11901,7 +11930,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -12060,7 +12089,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -12071,7 +12100,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "test-case-core",
 ]
 
@@ -12116,7 +12145,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -12127,7 +12156,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -12306,7 +12335,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -12602,7 +12631,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -12753,9 +12782,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-hash"
@@ -12981,7 +13010,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "wasm-bindgen-shared",
 ]
 
@@ -13124,7 +13153,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -13194,7 +13223,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -13205,7 +13234,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -13665,7 +13694,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "synstructure 0.13.2",
 ]
 
@@ -13686,7 +13715,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -13706,7 +13735,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "synstructure 0.13.2",
 ]
 
@@ -13727,7 +13756,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -13760,7 +13789,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ opt-level = 3
 #
 # There is a similar override in `programs/sbf/Cargo.toml`.  Please keep both
 # comments and the overrides in sync.
-solana-curve25519 = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d"}
+solana-curve25519 = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466"}
 
 [package]
 version = "0.1.0"
@@ -88,275 +88,275 @@ used_underscore_binding = "deny"
 
 
 [dependencies]
-Inflector = "=0.11.4"
-aes-gcm-siv = "=0.11.1"
-agave-banking-stage-ingress-types = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-cargo-registry = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0"}
-agave-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-fs = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-geyser-plugin-interface = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0"}
-agave-io-uring = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-logger = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-precompiles = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-reserved-account-keys = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-scheduler-bindings = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-scheduling-utils = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-snapshots = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-syscalls = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-thread-manager = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-transaction-view = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-verified-packet-receiver = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-votor = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-votor-messages = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-xdp = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-xdp-ebpf = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-ahash = "=0.8.12"
-anyhow = "=1.0.100"
-aquamarine = "=0.6.0"
-arbitrary = "=1.4.2"
-arc-swap = "=1.7.1"
-ark-bn254 = "=0.5.0"
+Inflector = "0.11.4"
+aes-gcm-siv = "0.11.1"
+agave-banking-stage-ingress-types = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-cargo-registry = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
+agave-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-fs = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-geyser-plugin-interface = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
+agave-io-uring = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-logger = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-precompiles = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-reserved-account-keys = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-scheduler-bindings = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-scheduling-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-snapshots = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-syscalls = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-thread-manager = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-transaction-view = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-verified-packet-receiver = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-votor = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-votor-messages = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-xdp = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-xdp-ebpf = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+ahash = "0.8.11"
+anyhow = "1.0.100"
+aquamarine = "0.6.0"
+arbitrary = "1.4.2"
+arc-swap = "1.7.1"
+ark-bn254 = "0.5.0"
 ark-bn254-0-4 = { package = "ark-bn254", version = "0.4.0" }
 array-bytes = "=1.4.1"
-arrayref = "=0.3.9"
-arrayvec = "=0.7.6"
-assert_cmd = "=2.1.1"
-assert_matches = "=1.5.0"
-async-lock = "=3.4.1"
-async-trait = "=0.1.89"
-atty = "=0.2.14"
-axum = "=0.8.6"
-aya = "=0.13.1"
+arrayref = "0.3.9"
+arrayvec = "0.7.6"
+assert_cmd = "2.0"
+assert_matches = "1.5.0"
+async-lock = "3.4.1"
+async-trait = "0.1.89"
+atty = "0.2.11"
+axum = "0.8.6"
+aya = "=0.13.0"
 aya-ebpf = "=0.1.1"
-backoff = "=0.4.0"
-base64 = "=0.22.1"
-bencher = "=0.1.5"
-bincode = "=1.3.3"
-bitflags = { version = "=2.10.0" }
-bitvec = { version = "=1.0.1", features = ["serde"] }
-blake3 = "=1.8.2"
-borsh = { version = "=1.5.7", features = ["derive", "unstable__schema"] }
-bs58 = { version = "=0.5.1", default-features = false }
-bv = "=0.11.1"
+backoff = "0.4.0"
+base64 = "0.22.1"
+bencher = "0.1.5"
+bincode = "1.3.3"
+bitflags = { version = "2.9.4" }
+bitvec = { version = "1.0.1", features = ["serde"] }
+blake3 = "1.8.2"
+borsh = { version = "1.5.7", features = ["derive", "unstable__schema"] }
+bs58 = { version = "0.5.1", default-features = false }
+bv = "0.11.1"
 byte-unit = "4.0.19"
-bytemuck = "=1.24.0"
-bytemuck_derive = "=1.10.2"
-bytes = "=1.10.1"
-bzip2 = "=0.4.4"
-caps = "=0.5.6"
-cargo_metadata = "=0.15.4"
-cfg-if = "=1.0.4"
-cfg_eval = "=0.1.2"
-chrono = { version = "=0.4.42", default-features = false }
-chrono-humanize = "=0.2.3"
-clap = { version = "=4.5.51", features = ["derive"] }
-console = "=0.16.1"
+bytemuck = "1.24.0"
+bytemuck_derive = "1.10.2"
+bytes = "1.10"
+bzip2 = "0.4.4"
+caps = "0.5.5"
+cargo_metadata = "0.15.4"
+cfg-if = "1.0.4"
+cfg_eval = "0.1.2"
+chrono = { version = "0.4.42", default-features = false }
+chrono-humanize = "0.2.3"
+clap = { version = "4.5.2", features = ["derive"] }
+console = "0.16.1"
 console_error_panic_hook = "0.1.7"
 console_log = "0.2.2"
-const_format = "=0.2.35"
-core_affinity = "=0.5.10"
-criterion = "=0.5.1"
-criterion-stats = "=0.3.0"
-crossbeam-channel = "=0.5.15"
-csv = "=1.4.0"
-ctrlc = "=3.5.1"
-curve25519-dalek = { version = "=4.1.3", features = ["digest", "rand_core"] }
-dashmap = "=5.5.3"
-derivation-path = { version = "=0.2.0", default-features = false }
-derive-where = "=1.6.0"
-derive_more = { version = "=2.0.1", features = ["full"] }
-dialoguer = "=0.10.4"
-digest = "=0.10.7"
-dir-diff = "=0.3.3"
-dirs-next = "=2.0.0"
-dlopen2 = "=0.5.0"
-dyn-clone = "=1.0.20"
-eager = "=0.1.0"
-ed25519-dalek = "=2.2.0"
-ed25519-dalek-bip32 = "=0.3.0"
-enum-iterator = "=1.5.0"
-env_logger = "=0.11.8"
-fast-math = "=0.1.1"
-fd-lock = "=3.0.13"
-five8_const = "=0.1.4"
-flate2 = "=1.1.5"
-fnv = "=1.0.7"
-fs_extra = "=1.3.0"
-futures = "=0.3.31"
-futures-util = "=0.3.31"
-gag = "=1.0.0"
-gethostname = "=0.2.3"
-getrandom = "=0.3.4"
-goauth = "=0.13.1"
-governor = "=0.6.3"
-hex = "=0.4.3"
-hidapi = { version = "=2.6.3", default-features = false }
-histogram = "=0.6.9"
-hmac = "=0.12.1"
-home = "=0.5.11"
-http = "=1.3.1"
-humantime = "=2.3.0"
-hyper = "=1.7.0"
-hyper-proxy = "=0.9.1"
-im = "=15.1.0"
-indexmap = "=2.12.0"
-indicatif = "=0.18.2"
-io-uring = "=0.7.11"
-itertools = "=0.13.0"
-jemallocator = { package = "tikv-jemallocator", version = "=0.6.1", features = [
+const_format = "0.2.35"
+core_affinity = "0.5.10"
+criterion = "0.5.1"
+criterion-stats = "0.3.0"
+crossbeam-channel = "0.5.15"
+csv = "1.4.0"
+ctrlc = "3.5.0"
+curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }
+dashmap = "5.5.3"
+derivation-path = { version = "0.2.0", default-features = false }
+derive-where = "1.6.0"
+derive_more = { version = "2.0.1", features = ["full"] }
+dialoguer = "0.10.4"
+digest = "0.10.7"
+dir-diff = "0.3.3"
+dirs-next = "2.0.0"
+dlopen2 = "0.5.0"
+dyn-clone = "1.0.20"
+eager = "0.1.0"
+ed25519-dalek = "=1.0.1"
+ed25519-dalek-bip32 = "0.2.0"
+enum-iterator = "1.5.0"
+env_logger = "0.11.8"
+fast-math = "0.1"
+fd-lock = "3.0.13"
+five8_const = "0.1.4"
+flate2 = "1.0.31"
+fnv = "1.0.7"
+fs_extra = "1.3.0"
+futures = "0.3.31"
+futures-util = "0.3.29"
+gag = "1.0.0"
+gethostname = "0.2.3"
+getrandom = "0.3.4"
+goauth = "0.13.1"
+governor = "0.6.3"
+hex = "0.4.3"
+hidapi = { version = "2.6.3", default-features = false }
+histogram = "0.6.9"
+hmac = "0.12.1"
+home = "0.5.11"
+http = "0.2.12"
+humantime = "2.3.0"
+hyper = "0.14.32"
+hyper-proxy = "0.9.1"
+im = "15.1.0"
+indexmap = "2.11.4"
+indicatif = "0.18.0"
+io-uring = "0.7.10"
+itertools = "0.12.1"
+jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
     "unprefixed_malloc_on_supported_platforms",
 ] }
-js-sys = "=0.3.82"
-json5 = "=0.4.1"
-jsonrpc-core = "=18.0.0"
-jsonrpc-core-client = "=18.0.0"
-jsonrpc-derive = "=18.0.0"
-jsonrpc-http-server = "=18.0.0"
-jsonrpc-ipc-server = "=18.0.0"
-jsonrpc-pubsub = "=18.0.0"
-lazy-lru = "=0.1.4"
-libc = "=0.2.177"
-libloading = "=0.7.4"
-libsecp256k1 = { version = "=0.6.0", default-features = false, features = [
+js-sys = "0.3.81"
+json5 = "0.4.1"
+jsonrpc-core = "18.0.0"
+jsonrpc-core-client = "18.0.0"
+jsonrpc-derive = "18.0.0"
+jsonrpc-http-server = "18.0.0"
+jsonrpc-ipc-server = "18.0.0"
+jsonrpc-pubsub = "18.0.0"
+lazy-lru = "0.1.3"
+libc = "0.2.177"
+libloading = "0.7.4"
+libsecp256k1 = { version = "0.6.0", default-features = false, features = [
     "std",
     "static-context",
 ] }
-light-poseidon = "=0.4.0"
+light-poseidon = "0.4.0"
 light-poseidon-0-2 = { package = "light-poseidon", version = "0.2.0" }
-log = "=0.4.28"
-lru = "=0.7.8"
-lz4 = "=1.28.1"
-memmap2 = "=0.9.9"
-memoffset = "=0.9.1"
-merlin = { version = "=3.0.0", default-features = false }
-min-max-heap = "=1.3.0"
-mockall = "=0.11.4"
-modular-bitfield = "=0.13.0"
-nix = "=0.30.1"
-num-bigint = "=0.4.6"
-num-derive = "=0.4.2"
-num-traits = "=0.2.19"
-num_cpus = "=1.17.0"
-num_enum = "=0.7.5"
-openssl = "=0.10.74"
-parking_lot = "=0.12.5"
-pbkdf2 = { version = "=0.12.2", default-features = false }
-pem = "=1.1.1"
-percentage = "=0.1.0"
-predicates = "=3.1.3"
-pretty-hex = "=0.3.0"
-pretty_assertions = "=1.4.1"
-prio-graph = "=0.3.0"
-proc-macro2 = "=1.0.103"
-proptest = "=1.9.0"
-prost = "=0.11.9"
-prost-build = "=0.11.9"
-prost-types = "=0.11.9"
-protobuf-src = "=1.1.0"
-qstring = "=0.7.2"
-qualifier_attr = { version = "=0.2.2", default-features = false }
-quinn = "=0.11.9"
-quinn-proto = "=0.11.13"
-quote = "=1.0.41"
-rand = "=0.9.2"
+log = "0.4.28"
+lru = "0.7.7"
+lz4 = "1.28.1"
+memmap2 = "0.9.8"
+memoffset = "0.9"
+merlin = { version = "3", default-features = false }
+min-max-heap = "1.3.0"
+mockall = "0.11.4"
+modular-bitfield = "0.13.0"
+nix = "0.30.1"
+num-bigint = "0.4.6"
+num-derive = "0.4"
+num-traits = "0.2"
+num_cpus = "1.17.0"
+num_enum = "0.7.4"
+openssl = "0.10"
+parking_lot = "0.12"
+pbkdf2 = { version = "0.12.2", default-features = false }
+pem = "1.1.1"
+percentage = "0.1.0"
+predicates = "2.1"
+pretty-hex = "0.3.0"
+pretty_assertions = "1.4.1"
+prio-graph = "0.3.0"
+proc-macro2 = "1.0.97"
+proptest = "1.8"
+prost = "0.11.9"
+prost-build = "0.11.9"
+prost-types = "0.11.9"
+protobuf-src = "1.1.0"
+qstring = "0.7.2"
+qualifier_attr = { version = "0.2.2", default-features = false }
+quinn = "0.11.9"
+quinn-proto = "0.11.13"
+quote = "1.0"
+rand = "0.8.5"
 rand0-7 = { package = "rand", version = "0.7" }
-rand_chacha = "=0.9.0"
+rand_chacha = "0.3.1"
 rand_chacha0-2 = { package = "rand_chacha", version = "0.2.2" }
-rayon = "=1.11.0"
-reed-solomon-erasure = "=6.0.0"
-regex = "=1.12.2"
-reqwest = { version = "=0.12.24", default-features = false }
-reqwest-middleware = "=0.4.2"
-rolling-file = "=0.2.0"
-rpassword = "=7.4.0"
-rts-alloc = { version = "=0.2.0" }
-rustls = { version = "=0.23.35", features = ["std"], default-features = false }
-scopeguard = "=1.2.0"
-semver = "=1.0.27"
-seqlock = "=0.2.0"
-serde = { version = "=1.0.228", features = ["derive"] }
-serde-big-array = "=0.5.1"
-serde_bytes = "=0.11.19"
-serde_json = "=1.0.145"
-serde_with = { version = "=3.15.1", default-features = false }
-serde_yaml = "=0.9.34"
-serial_test = "=2.0.0"
-sha2 = "=0.10.9"
-sha3 = "=0.10.8"
-shaq = { version = "=0.2.0" }
-shuttle = "=0.7.1"
-signal-hook = "=0.3.18"
-siphasher = "=1.0.1"
-slab = "=0.4.11"
-smallvec = { version = "=1.15.1", default-features = false, features = ["union"] }
-smpl_jwt = "=0.7.1"
-socket2 = "=0.6.1"
-soketto = "=0.7.1"
+rayon = "1.11.0"
+reed-solomon-erasure = "6.0.0"
+regex = "1.12.2"
+reqwest = { version = "0.12.24", default-features = false }
+reqwest-middleware = "0.4.2"
+rolling-file = "0.2.0"
+rpassword = "7.4"
+rts-alloc = { version = "0.2.0" }
+rustls = { version = "0.23.34", features = ["std"], default-features = false }
+scopeguard = "1.2.0"
+semver = "1.0.27"
+seqlock = "0.2.0"
+serde = { version = "1.0.228", features = ["derive"] }
+serde-big-array = "0.5.1"
+serde_bytes = "0.11.19"
+serde_json = "1.0.145"
+serde_with = { version = "3.15.0", default-features = false }
+serde_yaml = "0.9.34"
+serial_test = "2.0.0"
+sha2 = "0.10.9"
+sha3 = "0.10.8"
+shaq = { version = "0.2.0" }
+shuttle = "0.7.1"
+signal-hook = "0.3.18"
+siphasher = "1.0.1"
+slab = "0.4.11"
+smallvec = { version = "1.15.1", default-features = false, features = ["union"] }
+smpl_jwt = "0.7.1"
+socket2 = "0.6.1"
+soketto = "0.7"
 solana-account = "=3.2.0"
-solana-account-decoder = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-account-decoder-client-types = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-account-decoder = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-account-decoder-client-types = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-account-info = "=3.0.0"
-solana-accounts-db = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-accounts-db = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
 solana-address = "=1.0.0"
 solana-address-lookup-table-interface = "=3.0.0"
 solana-atomic-u64 = "=3.0.0"
-solana-banks-client = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-banks-interface = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-banks-server = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-banks-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-banks-interface = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-banks-server = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-big-mod-exp = "=3.0.0"
 solana-bincode = "=3.0.0"
 solana-blake3-hasher = "=3.0.0"
-solana-bloom = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-bloom = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-bls-signatures = { version = "=1.0.0", features = ["serde"] }
 solana-bn254 = "=3.1.2"
 solana-borsh = "=3.0.0"
-solana-bpf-loader-program = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-bucket-map = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-builtins = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-builtins-default-costs = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-clap-utils = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-clap-v3-utils = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-cli = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0"}
-solana-cli-config = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0"}
-solana-cli-output = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-client = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0"}
+solana-bpf-loader-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-bucket-map = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-builtins = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-builtins-default-costs = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-clap-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-clap-v3-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-cli = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
+solana-cli-config = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
+solana-cli-output = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
 solana-client-traits = "=3.0.0"
 solana-clock = "=3.0.0"
 solana-cluster-type = "=3.0.0"
 solana-commitment-config = "=3.0.0"
-solana-compute-budget = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-compute-budget-instruction = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-compute-budget = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-compute-budget-instruction = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
 solana-compute-budget-interface = "=3.0.0"
-solana-compute-budget-program = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-compute-budget-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-config-interface = "=2.0.0"
-solana-connection-cache = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-core = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-cost-model = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-connection-cache = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-core = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-cost-model = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-cpi = "=3.0.0"
-solana-curve25519 = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-curve25519 = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-define-syscall = "=3.0.0"
 solana-derivation-path = "=3.0.0"
-solana-download-utils = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-download-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-ed25519-program = "=3.0.0"
-solana-entry = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-entry = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-epoch-info = "=3.0.0"
 solana-epoch-rewards = "=3.0.0"
 solana-epoch-rewards-hasher = "=3.0.0"
 solana-epoch-schedule = "=3.0.0"
 solana-example-mocks = "=3.0.0"
-solana-faucet = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-faucet = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-feature-gate-interface = "=3.0.0"
-solana-fee = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-fee = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-fee-calculator = "=3.0.0"
 solana-fee-structure = "=3.0.0"
 solana-file-download = "=3.1.0"
 solana-frozen-abi = "=3.0.1"
 solana-frozen-abi-macro = "=3.0.1"
-solana-genesis = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-genesis = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-genesis-config = "=3.0.0"
-solana-genesis-utils = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-geyser-plugin-manager = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-gossip = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-genesis-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-geyser-plugin-manager = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-gossip = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-hard-forks = "=3.0.0"
 solana-hash = "=3.0.0"
 solana-inflation = "=3.0.0"
@@ -366,56 +366,56 @@ solana-instructions-sysvar = "=3.0.0"
 solana-keccak-hasher = "=3.0.0"
 solana-keypair = "=3.0.1"
 solana-last-restart-slot = "=3.0.0"
-solana-lattice-hash = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-ledger = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-lattice-hash = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-ledger = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
 solana-loader-v2-interface = "=3.0.0"
 solana-loader-v3-interface = "=6.1.0"
 solana-loader-v4-interface = "=3.1.0"
-solana-loader-v4-program = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-local-cluster = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-measure = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-merkle-tree = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-loader-v4-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-local-cluster = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-measure = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-merkle-tree = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-message = "=3.0.1"
-solana-metrics = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-metrics = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-msg = "=3.0.0"
 solana-native-token = "=3.0.0"
-solana-net-utils = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-net-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-nohash-hasher = "=0.2.1"
 solana-nonce = "=3.0.0"
 solana-nonce-account = "=3.0.0"
-solana-notifier = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-notifier = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-offchain-message = "=3.0.0"
 solana-packet = "=3.0.0"
-solana-perf = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-poh = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-perf = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-poh = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-poh-config = "=3.0.0"
-solana-poseidon = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-poseidon = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-precompile-error = "=3.0.0"
 solana-presigner = "=3.0.0"
 solana-program = { version = "=3.0.0", default-features = false }
-solana-program-binaries = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-program-binaries = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-program-entrypoint = "=3.1.0"
 solana-program-error = "=3.0.0"
 solana-program-memory = "=3.0.0"
 solana-program-option = "=3.0.0"
 solana-program-pack = "=3.0.0"
-solana-program-runtime = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-program-test = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-program-runtime = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-program-test = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-pubkey = { version = "=3.0.0", default-features = false }
-solana-pubsub-client = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0"}
-solana-quic-client = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-pubsub-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
+solana-quic-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-quic-definitions = "=3.0.0"
-solana-rayon-threadlimit = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-remote-wallet = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-rayon-threadlimit = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-remote-wallet = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-rent = "=3.0.0"
 solana-reward-info = "=3.0.0"
-solana-rpc = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-rpc-client = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0"}
-solana-rpc-client-api = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0"}
-solana-rpc-client-nonce-utils = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0"}
-solana-rpc-client-types = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0"}
-solana-runtime = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-runtime-transaction = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-rpc = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-rpc-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
+solana-rpc-client-api = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
+solana-rpc-client-nonce-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
+solana-rpc-client-types = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
+solana-runtime = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-runtime-transaction = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
 solana-sanitize = "=3.0.1"
 solana-sbpf = { git = "https://github.com/firedancer-io/sbpf", branch = "sbpf-v0.13.0-patches", version = "=0.13.0", default-features = false }
 solana-sdk-ids = "=3.0.0"
@@ -424,7 +424,7 @@ solana-secp256k1-recover = "=3.0.0"
 solana-secp256r1-program = "=3.0.0"
 solana-seed-derivable = "=3.0.0"
 solana-seed-phrase = "=3.0.0"
-solana-send-transaction-service = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-send-transaction-service = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-serde = "=3.0.0"
 solana-serde-varint = "=3.0.0"
 solana-serialize-utils = "=3.1.0"
@@ -438,50 +438,50 @@ solana-slot-hashes = "=3.0.0"
 solana-slot-history = "=3.0.0"
 solana-stable-layout = "=3.0.0"
 solana-stake-interface = { version = "=2.0.1" }
-solana-stake-program = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-storage-bigtable = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-storage-proto = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-streamer = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-svm-callback = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm-log-collector = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm-measure = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm-test-harness = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0"}
-solana-svm-timings = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm-transaction = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm-type-overrides = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-stake-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-storage-bigtable = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-storage-proto = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-streamer = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-svm-callback = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm-log-collector = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm-measure = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm-test-harness = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
+solana-svm-timings = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm-transaction = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm-type-overrides = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-system-interface = "=2.0.0"
-solana-system-program = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-system-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-system-transaction = "=3.0.0"
 solana-sysvar = "=3.0.0"
 solana-sysvar-id = "=3.0.0"
-solana-test-validator = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0"}
+solana-test-validator = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
 solana-time-utils = "=3.0.0"
-solana-tls-utils = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-tps-client = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-tpu-client = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-tpu-client-next = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-tls-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-tps-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-tpu-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-tpu-client-next = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-transaction = "=3.0.1"
-solana-transaction-context = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]}
+solana-transaction-context = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]}
 solana-transaction-error = "=3.0.0"
-solana-transaction-metrics-tracker = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-transaction-status = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-transaction-status-client-types = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-turbine = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-udp-client = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-unified-scheduler-logic = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-unified-scheduler-pool = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-transaction-metrics-tracker = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-transaction-status = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-transaction-status-client-types = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-turbine = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-udp-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-unified-scheduler-logic = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-unified-scheduler-pool = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-validator-exit = "=3.0.0"
-solana-version = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-vote = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-version = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-vote = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
 solana-vote-interface = "=4.0.4"
-solana-vote-program = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-wen-restart = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-zk-elgamal-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-vote-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-wen-restart = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-zk-elgamal-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-zk-sdk = "=4.0.0"
-solana-zk-token-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-zk-token-sdk = {git = "https://github.com/firedancer-io/agave", rev = "69f8b729eba4a889304cd101109031f245593f7d", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-zk-token-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-zk-token-sdk = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 spl-associated-token-account-interface = "=2.0.0"
 spl-generic-token = "=2.0.1"
 spl-memo-interface = "=2.0.0"
@@ -491,51 +491,56 @@ spl-token-confidential-transfer-proof-extraction = "=0.5.1"
 spl-token-group-interface = "=0.7.1"
 spl-token-interface = "=2.0.0"
 spl-token-metadata-interface = "=0.8.0"
-static_assertions = "=1.1.0"
-stream-cancel = "=0.8.2"
-strum = "=0.24.1"
-strum_macros = "=0.24.3"
-subtle = "=2.6.1"
-symlink = "=0.1.0"
-syn = "=2.0.108"
-sys-info = "=0.9.1"
-sysctl = "=0.4.6"
-systemstat = "=0.2.5"
-tar = "=0.4.44"
-tarpc = "=0.29.0"
-tempfile = "=3.23.0"
-test-case = "=3.3.1"
-thiserror = "=2.0.17"
-thread-priority = "=1.2.0"
-tiny-bip39 = "=2.0.0"
-tokio = "=1.48.0"
-tokio-serde = "=0.8.0"
-tokio-stream = "=0.1.17"
-tokio-tungstenite = "=0.28.0"
-tokio-util = "=0.7.17"
-toml = "=0.9.8"
-tonic = "=0.9.2"
-tonic-build = "=0.9.2"
-tower = "=0.5.2"
-tracing = "=0.1.41"
-trait-set = "=0.3.0"
-trees = "=0.4.2"
-tungstenite = "=0.28.0"
-unwrap_none = "=0.1.2"
-uriparse = "=0.6.4"
-url = "=2.5.7"
-vec_extract_if_polyfill = "=0.1.0"
-wasm-bindgen = "=0.2.105"
-winapi = "=0.3.9"
-wincode = { version = "=0.1.2", features = ["derive", "solana-short-vec"] }
-x509-parser = "=0.14.0"
-zeroize = { version = "=1.8.2", default-features = false }
-zstd = "=0.13.3"
-protosol = {git = "https://github.com/firedancer-io/protosol", tag = "v3.0.0", version = "=3.0.0"}
+static_assertions = "1.1.0"
+stream-cancel = "0.8.2"
+strum = "0.24"
+strum_macros = "0.24"
+subtle = "2.6.1"
+symlink = "0.1.0"
+syn = "2.0"
+sys-info = "0.9.1"
+sysctl = "0.4.6"
+systemstat = "0.2.5"
+tar = "0.4.44"
+tarpc = "0.29.0"
+tempfile = "3.23.0"
+test-case = "3.3.1"
+thiserror = "2.0.17"
+thread-priority = "1.2.0"
+tiny-bip39 = "2.0.0"
+tokio = "1.48.0"
+tokio-serde = "0.8"
+tokio-stream = "0.1.17"
+tokio-tungstenite = "0.28.0"
+tokio-util = "0.7.16"
+toml = "0.9.8"
+tonic = "0.9.2"
+tonic-build = "0.9.2"
+tower = "0.5.2"
+tracing = "0.1"
+trait-set = "0.3.0"
+trees = "0.4.2"
+tungstenite = "0.28.0"
+unwrap_none = "0.1.2"
+uriparse = "0.6.4"
+url = "2.5.7"
+vec_extract_if_polyfill = "0.1.0"
+wasm-bindgen = "0.2"
+winapi = "0.3.8"
+wincode = { version = "0.1.2", features = ["derive", "solana-short-vec"] }
+x509-parser = "0.14.0"
+zeroize = { version = "1.8", default-features = false }
+zstd = "0.13.3"
+protosol = {git = "https://github.com/firedancer-io/protosol", tag = "v3.0.0"}
 solfuzz-agave-macro = { path = "macro" }
-once_cell = "=1.21.3"
-lazy_static = "=1.5.0"
+once_cell = "1.21.3"
+lazy_static = "1.5.0"
 flatbuffers = "25.9.23"
+aya-obj = "=0.2.1"
+aya-build = "=0.1.2"
+aya-ebpf-cty = "=0.2.2"
+aya-ebpf-macros = "=0.1.1"
+aya-ebpf-bindings = "=0.1.1"
 
 [[bench]]
 name = "bench_txn"

--- a/scripts/generate_cargo.py
+++ b/scripts/generate_cargo.py
@@ -172,6 +172,9 @@ def pin_dependencies(toml_data, lockfile_path):
     sections = ["dependencies", "dev-dependencies", "build-dependencies"]
     pinned_names = set()
 
+    def is_solana_crate(name: str) -> bool:
+        return name.startswith(("solana-", "agave-", "spl-"))
+
     for section in sections:
         deps = toml_data.get(section, {})
         for dep_name, val in deps.items():
@@ -186,6 +189,32 @@ def pin_dependencies(toml_data, lockfile_path):
                 continue
             pinned_names.add(package_name)
 
+            # Only pin Solana-related crates; leave 3rd-party crates with their
+            # semver ranges so Cargo can select non-yanked patch versions.
+            if not is_solana_crate(package_name):
+                continue
+
+            # Do not override versions for local path dependencies.
+            # These point at the local Agave workspace and must match
+            # the workspace crate version (often a prerelease).
+            if isinstance(val, dict) and "path" in val:
+                continue
+
+            # Do not override versions that are already exactly pinned in the overlay.
+            # This allows solfuzz_agave.toml to override Agave's lockfile versions
+            # (e.g. solana-epoch-rewards-hasher =3.0.0 to avoid solana-hash conflicts).
+            def is_already_exact_pinned(v):
+                if isinstance(v, str):
+                    return v.strip().startswith("=")
+                elif isinstance(v, dict):
+                    ver = v.get("version", "")
+                    return isinstance(ver, str) and ver.strip().startswith("=")
+                return False
+
+            if is_already_exact_pinned(val):
+                continue
+
+            # Fall back to the version present in the Agave lockfile if none declared
             if package_name not in version_map:
                 continue
 

--- a/solfuzz_agave.toml
+++ b/solfuzz_agave.toml
@@ -15,6 +15,14 @@ lazy_static = "1.5.0"
 home = "0.5.11"
 flatbuffers = "25.9.23"
 
+# SPL compatibility pins:
+# spl-type-length-value (^0.9.0) and spl-token-2022-interface (^2.0.0) on crates.io
+# require spl-pod >= 0.7.1 and spl-token-group-interface >= 0.7.1.
+# Pin to 0.7.1 here to prevent the resolver selecting older 0.7.0, which
+# conflicts with upstream SPL constraints during lockfile generation.
+spl-pod = "0.7.1"
+spl-token-group-interface = "0.7.1"
+
 # Enable dev-context-only-utils for Agave dependencies that need it
 solana-runtime = { features = ["dev-context-only-utils"] }
 solana-accounts-db = { features = ["dev-context-only-utils"] }
@@ -27,6 +35,25 @@ solana-compute-budget-instruction = { features = ["dev-context-only-utils"] }
 solana-core = { features = ["dev-context-only-utils"] }
 solana-ledger = { features = ["dev-context-only-utils"] }
 solana-perf = { features = ["dev-context-only-utils"] }
+
+# Aya stack pins (keep Linux builds on rustc 1.86.0):
+# Newer aya subcrates require rustc 1.87.0. We pin the aya family to pre-1.87
+# versions so that including turbine/XDP on Linux does not bump the toolchain.
+# If XDP is excluded, these remain inert, but the pins ensure reproducibility.
+aya = "=0.13.0"
+aya-obj = "=0.2.1"
+aya-build = "=0.1.2"
+aya-ebpf-cty = "=0.2.2"
+aya-ebpf-macros = "=0.1.1"
+aya-ebpf = "=0.1.1"
+aya-ebpf-bindings = "=0.1.1"
+
+# Keep solana-hash and solana-epoch-rewards-hasher aligned with Agave’s manifest
+# to avoid mixed solana-hash (3.0.0 vs 4.0.1) in the graph, which causes type
+# duplication and E0308 mismatches. Some crates on crates.io (e.g. solana-message)
+# depend on solana-hash 4.0.1, but Agave uses 3.0.0, so we pin both to match.
+solana-hash = "=3.0.0"
+solana-epoch-rewards-hasher = "=3.0.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
- Add extra logic to generate_cargo.py to respect the exact version pins in solfuzz_agave.toml throughout the entire dependency tree.

- Scope exact-pinning to Solana-related crates only, letting third-party crates use semver semantics so Cargo can select
non-yanked patch versions.

- Adds explicit pins in solfuzz_agave.toml for SPL compatibility, Aya stack (we need to force the usage of Rust 1.86.0 packages), and solana-hash / solana-epoch-rewards-hasher (there will be duplicate types if these versions conflict).

- Regenerated out of the box Cargo / lock file with Agave dependencies using new logic.