### PR TITLE
instr, bpf serialization: correctly handle instruction account limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 [[package]]
 name = "agave-banking-stage-ingress-types"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -78,7 +78,7 @@ dependencies = [
 [[package]]
 name = "agave-cargo-registry"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-logger",
  "clap 2.34.0",
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 name = "agave-feature-set"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule",
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "agave-fs"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -136,7 +136,7 @@ dependencies = [
 [[package]]
 name = "agave-geyser-plugin-interface"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "log",
  "solana-clock",
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "agave-io-uring"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "io-uring",
  "libc",
@@ -162,7 +162,7 @@ dependencies = [
 [[package]]
 name = "agave-logger"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "env_logger",
  "libc",
@@ -173,7 +173,7 @@ dependencies = [
 [[package]]
 name = "agave-precompiles"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -194,7 +194,7 @@ dependencies = [
 [[package]]
 name = "agave-reserved-account-keys"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey 3.0.0",
@@ -204,12 +204,12 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 
 [[package]]
 name = "agave-scheduling-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-scheduler-bindings",
  "agave-transaction-view",
@@ -226,7 +226,7 @@ dependencies = [
 [[package]]
 name = "agave-snapshots"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-fs",
  "bincode",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "agave-syscalls"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "bincode",
  "libsecp256k1",
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "agave-thread-manager"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "affinity",
  "anyhow",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "agave-transaction-view"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "solana-hash 3.0.0",
  "solana-message",
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "agave-verified-packet-receiver"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "solana-perf",
  "solana-streamer",
@@ -339,7 +339,7 @@ dependencies = [
 [[package]]
 name = "agave-votor"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-logger",
  "agave-votor-messages",
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "agave-votor-messages"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-logger",
  "serde",
@@ -403,7 +403,7 @@ dependencies = [
 [[package]]
 name = "agave-xdp"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-xdp-ebpf",
  "aya",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "agave-xdp-ebpf"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "aya",
  "aya-ebpf",
@@ -6892,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -6933,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder-client-types"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6960,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "solana-accounts-db"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-fs",
  "ahash 0.8.12",
@@ -7082,7 +7082,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "borsh",
  "futures 0.3.31",
@@ -7109,7 +7109,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-interface"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "serde",
  "solana-account",
@@ -7128,7 +7128,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-server"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "solana-bloom"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "bv",
  "fnv",
@@ -7251,7 +7251,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -7279,7 +7279,7 @@ dependencies = [
 [[package]]
 name = "solana-bucket-map"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "bv",
  "bytemuck",
@@ -7297,7 +7297,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -7317,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins-default-costs"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -7335,7 +7335,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -7364,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-v3-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "chrono",
  "clap 3.2.25",
@@ -7393,7 +7393,7 @@ dependencies = [
 [[package]]
 name = "solana-cli"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -7479,7 +7479,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-config"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "dirs-next",
  "serde",
@@ -7492,7 +7492,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-output"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -7533,7 +7533,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7635,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -7644,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-instruction"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -7675,7 +7675,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -7700,7 +7700,7 @@ dependencies = [
 [[package]]
 name = "solana-connection-cache"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "solana-core"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -7866,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "solana-cost-model"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -7907,7 +7907,7 @@ dependencies = [
 [[package]]
 name = "solana-curve25519"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -7966,7 +7966,7 @@ dependencies = [
 [[package]]
 name = "solana-download-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -7991,7 +7991,7 @@ dependencies = [
 [[package]]
 name = "solana-entry"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -8100,7 +8100,7 @@ dependencies = [
 [[package]]
 name = "solana-faucet"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-logger",
  "bincode",
@@ -8151,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "solana-fee"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -8227,7 +8227,7 @@ dependencies = [
 [[package]]
 name = "solana-genesis"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8305,7 +8305,7 @@ dependencies = [
 [[package]]
 name = "solana-genesis-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -8319,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "solana-geyser-plugin-manager"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -8350,7 +8350,7 @@ dependencies = [
 [[package]]
 name = "solana-gossip"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -8552,7 +8552,7 @@ dependencies = [
 [[package]]
 name = "solana-lattice-hash"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -8563,7 +8563,7 @@ dependencies = [
 [[package]]
 name = "solana-ledger"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -8707,7 +8707,7 @@ dependencies = [
 [[package]]
 name = "solana-loader-v4-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "log",
  "solana-account",
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "solana-local-cluster"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-logger",
  "agave-snapshots",
@@ -8794,12 +8794,12 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 
 [[package]]
 name = "solana-merkle-tree"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "fast-math",
  "solana-hash 3.0.0",
@@ -8829,7 +8829,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -8859,7 +8859,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 [[package]]
 name = "solana-net-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8913,7 +8913,7 @@ dependencies = [
 [[package]]
 name = "solana-notifier"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "log",
  "reqwest 0.12.24",
@@ -8954,7 +8954,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -8994,7 +8994,7 @@ dependencies = [
 [[package]]
 name = "solana-poh"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "arc-swap",
  "core_affinity",
@@ -9028,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "solana-poseidon"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-bn254 0.5.0",
@@ -9107,7 +9107,7 @@ dependencies = [
 [[package]]
 name = "solana-program-binaries"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "bincode",
  "serde",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9214,7 +9214,7 @@ dependencies = [
 [[package]]
 name = "solana-program-test"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -9307,7 +9307,7 @@ dependencies = [
 [[package]]
 name = "solana-pubsub-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -9332,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "solana-quic-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -9370,7 +9370,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "log",
  "num_cpus",
@@ -9379,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "console 0.16.1",
  "dialoguer",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9550,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-api"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -9570,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-nonce-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "clap 2.34.0",
  "solana-account",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-types"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -9614,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "agave-fs",
@@ -9751,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime-transaction"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -9887,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "solana-send-transaction-service"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -10077,7 +10077,7 @@ dependencies = [
 [[package]]
 name = "solana-stake-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -10099,7 +10099,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-bigtable"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -10139,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-proto"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "bincode",
  "bs58",
@@ -10164,7 +10164,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -10211,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-callback"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -10265,12 +10265,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-feature-set"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 
 [[package]]
 name = "solana-svm-log-collector"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "log",
 ]
@@ -10278,12 +10278,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-measure"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 
 [[package]]
 name = "solana-svm-test-harness"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -10316,7 +10316,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-timings"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -10326,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-transaction"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "solana-hash 3.0.0",
  "solana-message",
@@ -10339,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-type-overrides"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -10362,7 +10362,7 @@ dependencies = [
 [[package]]
 name = "solana-system-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "bincode",
  "log",
@@ -10446,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "solana-test-validator"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
@@ -10503,7 +10503,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 [[package]]
 name = "solana-tls-utils"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "rustls 0.23.35",
  "solana-keypair",
@@ -10515,7 +10515,7 @@ dependencies = [
 [[package]]
 name = "solana-tps-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "log",
  "solana-account",
@@ -10545,7 +10545,7 @@ dependencies = [
 [[package]]
 name = "solana-tpu-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "async-trait",
  "bincode",
@@ -10578,7 +10578,7 @@ dependencies = [
 [[package]]
 name = "solana-tpu-client-next"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "async-trait",
  "log",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -10655,7 +10655,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-metrics-tracker"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10670,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -10712,7 +10712,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status-client-types"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10735,7 +10735,7 @@ dependencies = [
 [[package]]
 name = "solana-turbine"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "agave-votor",
@@ -10790,7 +10790,7 @@ dependencies = [
 [[package]]
 name = "solana-udp-client"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -10805,7 +10805,7 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-logic"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "assert_matches",
  "solana-pubkey 3.0.0",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-pool"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -10859,7 +10859,7 @@ checksum = "c5d2face763df5afeaa9509b9019968860e69cc1531ec8b4a2e6c7b702204d5a"
 [[package]]
 name = "solana-version"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -10872,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "solana-vote"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "bincode",
  "itertools 0.12.1",
@@ -10926,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -10958,7 +10958,7 @@ dependencies = [
 [[package]]
 name = "solana-wen-restart"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-snapshots",
  "anyhow",
@@ -10987,7 +10987,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-elgamal-proof-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -11040,7 +11040,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-proof-program"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-sdk"
 version = "3.1.0-beta.0"
-source = "git+https://github.com/firedancer-io/agave?rev=9a9faeb12436e4be7871a47b1ecebfa17206d466#9a9faeb12436e4be7871a47b1ecebfa17206d466"
+source = "git+https://github.com/firedancer-io/agave?rev=19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e#19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ opt-level = 3
 #
 # There is a similar override in `programs/sbf/Cargo.toml`.  Please keep both
 # comments and the overrides in sync.
-solana-curve25519 = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466"}
+solana-curve25519 = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e"}
 
 [package]
 version = "0.1.0"
@@ -90,26 +90,26 @@ used_underscore_binding = "deny"
 [dependencies]
 Inflector = "0.11.4"
 aes-gcm-siv = "0.11.1"
-agave-banking-stage-ingress-types = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-cargo-registry = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
-agave-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-fs = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-geyser-plugin-interface = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
-agave-io-uring = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-logger = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-precompiles = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-reserved-account-keys = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-scheduler-bindings = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-scheduling-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-snapshots = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-syscalls = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-thread-manager = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-transaction-view = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-verified-packet-receiver = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-votor = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-votor-messages = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-xdp = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-agave-xdp-ebpf = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-banking-stage-ingress-types = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-cargo-registry = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0"}
+agave-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-fs = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-geyser-plugin-interface = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0"}
+agave-io-uring = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-logger = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-precompiles = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-reserved-account-keys = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-scheduler-bindings = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-scheduling-utils = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-snapshots = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-syscalls = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-thread-manager = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-transaction-view = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-verified-packet-receiver = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-votor = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-votor-messages = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-xdp = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+agave-xdp-ebpf = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 ahash = "0.8.11"
 anyhow = "1.0.100"
 aquamarine = "0.6.0"
@@ -293,70 +293,70 @@ smpl_jwt = "0.7.1"
 socket2 = "0.6.1"
 soketto = "0.7"
 solana-account = "=3.2.0"
-solana-account-decoder = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-account-decoder-client-types = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-account-decoder = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-account-decoder-client-types = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-account-info = "=3.0.0"
-solana-accounts-db = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-accounts-db = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
 solana-address = "=1.0.0"
 solana-address-lookup-table-interface = "=3.0.0"
 solana-atomic-u64 = "=3.0.0"
-solana-banks-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-banks-interface = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-banks-server = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-banks-client = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-banks-interface = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-banks-server = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-big-mod-exp = "=3.0.0"
 solana-bincode = "=3.0.0"
 solana-blake3-hasher = "=3.0.0"
-solana-bloom = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-bloom = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-bls-signatures = { version = "=1.0.0", features = ["serde"] }
 solana-bn254 = "=3.1.2"
 solana-borsh = "=3.0.0"
-solana-bpf-loader-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-bucket-map = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-builtins = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-builtins-default-costs = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-clap-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-clap-v3-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-cli = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
-solana-cli-config = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
-solana-cli-output = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
+solana-bpf-loader-program = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-bucket-map = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-builtins = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-builtins-default-costs = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-clap-utils = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-clap-v3-utils = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-cli = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0"}
+solana-cli-config = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0"}
+solana-cli-output = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-client = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0"}
 solana-client-traits = "=3.0.0"
 solana-clock = "=3.0.0"
 solana-cluster-type = "=3.0.0"
 solana-commitment-config = "=3.0.0"
-solana-compute-budget = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-compute-budget-instruction = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-compute-budget = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-compute-budget-instruction = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
 solana-compute-budget-interface = "=3.0.0"
-solana-compute-budget-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-compute-budget-program = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-config-interface = "=2.0.0"
-solana-connection-cache = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-core = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-cost-model = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-connection-cache = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-core = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-cost-model = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-cpi = "=3.0.0"
-solana-curve25519 = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-curve25519 = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-define-syscall = "=3.0.0"
 solana-derivation-path = "=3.0.0"
-solana-download-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-download-utils = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-ed25519-program = "=3.0.0"
-solana-entry = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-entry = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-epoch-info = "=3.0.0"
 solana-epoch-rewards = "=3.0.0"
 solana-epoch-rewards-hasher = "=3.0.0"
 solana-epoch-schedule = "=3.0.0"
 solana-example-mocks = "=3.0.0"
-solana-faucet = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-faucet = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-feature-gate-interface = "=3.0.0"
-solana-fee = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-fee = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-fee-calculator = "=3.0.0"
 solana-fee-structure = "=3.0.0"
 solana-file-download = "=3.1.0"
 solana-frozen-abi = "=3.0.1"
 solana-frozen-abi-macro = "=3.0.1"
-solana-genesis = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-genesis = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-genesis-config = "=3.0.0"
-solana-genesis-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-geyser-plugin-manager = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-gossip = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-genesis-utils = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-geyser-plugin-manager = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-gossip = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-hard-forks = "=3.0.0"
 solana-hash = "=3.0.0"
 solana-inflation = "=3.0.0"
@@ -366,56 +366,56 @@ solana-instructions-sysvar = "=3.0.0"
 solana-keccak-hasher = "=3.0.0"
 solana-keypair = "=3.0.1"
 solana-last-restart-slot = "=3.0.0"
-solana-lattice-hash = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-ledger = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-lattice-hash = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-ledger = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
 solana-loader-v2-interface = "=3.0.0"
 solana-loader-v3-interface = "=6.1.0"
 solana-loader-v4-interface = "=3.1.0"
-solana-loader-v4-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-local-cluster = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-measure = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-merkle-tree = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-loader-v4-program = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-local-cluster = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-measure = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-merkle-tree = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-message = "=3.0.1"
-solana-metrics = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-metrics = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-msg = "=3.0.0"
 solana-native-token = "=3.0.0"
-solana-net-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-net-utils = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-nohash-hasher = "=0.2.1"
 solana-nonce = "=3.0.0"
 solana-nonce-account = "=3.0.0"
-solana-notifier = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-notifier = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-offchain-message = "=3.0.0"
 solana-packet = "=3.0.0"
-solana-perf = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-poh = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-perf = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-poh = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-poh-config = "=3.0.0"
-solana-poseidon = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-poseidon = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-precompile-error = "=3.0.0"
 solana-presigner = "=3.0.0"
 solana-program = { version = "=3.0.0", default-features = false }
-solana-program-binaries = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-program-binaries = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-program-entrypoint = "=3.1.0"
 solana-program-error = "=3.0.0"
 solana-program-memory = "=3.0.0"
 solana-program-option = "=3.0.0"
 solana-program-pack = "=3.0.0"
-solana-program-runtime = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-program-test = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-program-runtime = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-program-test = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-pubkey = { version = "=3.0.0", default-features = false }
-solana-pubsub-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
-solana-quic-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-pubsub-client = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0"}
+solana-quic-client = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-quic-definitions = "=3.0.0"
-solana-rayon-threadlimit = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-remote-wallet = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-rayon-threadlimit = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-remote-wallet = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-rent = "=3.0.0"
 solana-reward-info = "=3.0.0"
-solana-rpc = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-rpc-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
-solana-rpc-client-api = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
-solana-rpc-client-nonce-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
-solana-rpc-client-types = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
-solana-runtime = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-runtime-transaction = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-rpc = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-rpc-client = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0"}
+solana-rpc-client-api = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0"}
+solana-rpc-client-nonce-utils = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0"}
+solana-rpc-client-types = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0"}
+solana-runtime = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-runtime-transaction = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
 solana-sanitize = "=3.0.1"
 solana-sbpf = { git = "https://github.com/firedancer-io/sbpf", branch = "sbpf-v0.13.0-patches", version = "=0.13.0", default-features = false }
 solana-sdk-ids = "=3.0.0"
@@ -424,7 +424,7 @@ solana-secp256k1-recover = "=3.0.0"
 solana-secp256r1-program = "=3.0.0"
 solana-seed-derivable = "=3.0.0"
 solana-seed-phrase = "=3.0.0"
-solana-send-transaction-service = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-send-transaction-service = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-serde = "=3.0.0"
 solana-serde-varint = "=3.0.0"
 solana-serialize-utils = "=3.1.0"
@@ -438,50 +438,50 @@ solana-slot-hashes = "=3.0.0"
 solana-slot-history = "=3.0.0"
 solana-stable-layout = "=3.0.0"
 solana-stake-interface = { version = "=2.0.1" }
-solana-stake-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-storage-bigtable = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-storage-proto = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-streamer = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-svm-callback = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm-log-collector = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm-measure = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm-test-harness = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
-solana-svm-timings = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm-transaction = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-svm-type-overrides = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-stake-program = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-storage-bigtable = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-storage-proto = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-streamer = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-svm-callback = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm-log-collector = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm-measure = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm-test-harness = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0"}
+solana-svm-timings = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm-transaction = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-svm-type-overrides = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-system-interface = "=2.0.0"
-solana-system-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-system-program = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-system-transaction = "=3.0.0"
 solana-sysvar = "=3.0.0"
 solana-sysvar-id = "=3.0.0"
-solana-test-validator = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0"}
+solana-test-validator = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0"}
 solana-time-utils = "=3.0.0"
-solana-tls-utils = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-tps-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-tpu-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-tpu-client-next = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-tls-utils = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-tps-client = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-tpu-client = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-tpu-client-next = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-transaction = "=3.0.1"
-solana-transaction-context = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]}
+solana-transaction-context = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]}
 solana-transaction-error = "=3.0.0"
-solana-transaction-metrics-tracker = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-transaction-status = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-transaction-status-client-types = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-turbine = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-udp-client = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-unified-scheduler-logic = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-unified-scheduler-pool = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-transaction-metrics-tracker = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-transaction-status = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-transaction-status-client-types = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-turbine = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-udp-client = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-unified-scheduler-logic = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-unified-scheduler-pool = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-validator-exit = "=3.0.0"
-solana-version = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-vote = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-version = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-vote = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
 solana-vote-interface = "=4.0.4"
-solana-vote-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-wen-restart = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-zk-elgamal-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-vote-program = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-wen-restart = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-zk-elgamal-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 solana-zk-sdk = "=4.0.0"
-solana-zk-token-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
-solana-zk-token-sdk = {git = "https://github.com/firedancer-io/agave", rev = "9a9faeb12436e4be7871a47b1ecebfa17206d466", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-zk-token-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
+solana-zk-token-sdk = {git = "https://github.com/firedancer-io/agave", rev = "19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e", version = "=3.1.0-beta.0", features = ["agave-unstable-api"]}
 spl-associated-token-account-interface = "=2.0.0"
 spl-generic-token = "=2.0.1"
 spl-memo-interface = "=2.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,6 +522,15 @@ impl TryFrom<proto::InstrContext> for InstrContext {
             .map(|acct_state| acct_state.try_into())
             .collect::<Result<Vec<_>, _>>()?;
 
+        // Match Firedancer harness limit (FD_INSTR_ACCT_MAX = 1094)
+        // which is derived from the MTU
+        // (see FD_BPF_INSTR_ACCT_MAX comment in Firedancer)
+        const MAX_INSTR_ACCOUNTS: usize = 1094;
+        assert!(
+            input.instr_accounts.len() <= MAX_INSTR_ACCOUNTS,
+            "invariant violation: too many instruction accounts"
+        );
+
         let instruction_accounts = input
             .instr_accounts
             .into_iter()


### PR DESCRIPTION
- Fail in context loading when there are >1094 instruction accounts (MTU-derived limit, see `FD_INSTR_ACCT_MAX` in Firedancer)
-  Bump Agave fork version to remove incorrect debug assertion https://github.com/firedancer-io/agave/commit/19b1c2b57ba2625bb5a6e3be673ffbc48d8bc55e