### PR TITLE
conformance: harness enforces infallible invariants

### DIFF
--- a/src/vm_interp.rs
+++ b/src/vm_interp.rs
@@ -145,7 +145,10 @@ pub fn vec_rtrim_zeros(v: &[u8]) -> Vec<u8> {
 pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffects> {
     let mut instr_ctx: InstrContext = syscall_context.instr_ctx?.try_into().ok()?;
 
-    let vm_ctx = syscall_context.vm_ctx.unwrap();
+    let Some(vm_ctx) = syscall_context.vm_ctx else {
+        // Match FD behavior: skip test if vm_ctx is missing
+        return None;
+    };
     let sbpf_version = match vm_ctx.sbpf_version {
         1 => SBPFVersion::V1,
         2 => SBPFVersion::V2,
@@ -243,14 +246,26 @@ pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffec
         .transaction_context
         .get_current_instruction_context()
         .unwrap();
+    let serialize_result = serialize_parameters(
+        &caller_instr_ctx,
+        stricter_abi_and_runtime_constraints,
+        direct_mapping,
+        mask_out_rent_epoch_in_vm_serialization,
+    );
     let (_aligned_memory, input_memory_regions, acc_metadatas, _instruction_data_offset) =
-        serialize_parameters(
-            &caller_instr_ctx,
-            stricter_abi_and_runtime_constraints,
-            direct_mapping,
-            mask_out_rent_epoch_in_vm_serialization,
-        )
-        .unwrap();
+        match serialize_result {
+            Ok(result) => result,
+            Err(e) => {
+                // Return effects with the serialization error
+                let error = crate::utils::err_map::instr_err_to_num(&e) as i64;
+                return Some(SyscallEffects {
+                    error,
+                    error_kind: crate::proto::ErrKind::Instruction as i32,
+                    cu_avail: invoke_ctx.get_remaining(),
+                    ..Default::default()
+                });
+            }
+        };
 
     let mut config = environments.program_runtime_v1.get_config().clone();
     config.enable_register_tracing = true;

--- a/src/vm_interp.rs
+++ b/src/vm_interp.rs
@@ -145,10 +145,9 @@ pub fn vec_rtrim_zeros(v: &[u8]) -> Vec<u8> {
 pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffects> {
     let mut instr_ctx: InstrContext = syscall_context.instr_ctx?.try_into().ok()?;
 
-    let Some(vm_ctx) = syscall_context.vm_ctx else {
-        // Match FD behavior: skip test if vm_ctx is missing
-        return None;
-    };
+    let vm_ctx = syscall_context
+        .vm_ctx
+        .expect("invariant violation: vm_ctx must be present for every execution");
     let sbpf_version = match vm_ctx.sbpf_version {
         1 => SBPFVersion::V1,
         2 => SBPFVersion::V2,
@@ -246,26 +245,16 @@ pub fn execute_vm_interp(syscall_context: SyscallContext) -> Option<SyscallEffec
         .transaction_context
         .get_current_instruction_context()
         .unwrap();
-    let serialize_result = serialize_parameters(
-        &caller_instr_ctx,
-        stricter_abi_and_runtime_constraints,
-        direct_mapping,
-        mask_out_rent_epoch_in_vm_serialization,
-    );
+    // serialize_parameters should never fail - the fuzzer now ensures
+    // valid instruction account counts, so unwrap is safe here
     let (_aligned_memory, input_memory_regions, acc_metadatas, _instruction_data_offset) =
-        match serialize_result {
-            Ok(result) => result,
-            Err(e) => {
-                // Return effects with the serialization error
-                let error = crate::utils::err_map::instr_err_to_num(&e) as i64;
-                return Some(SyscallEffects {
-                    error,
-                    error_kind: crate::proto::ErrKind::Instruction as i32,
-                    cu_avail: invoke_ctx.get_remaining(),
-                    ..Default::default()
-                });
-            }
-        };
+        serialize_parameters(
+            &caller_instr_ctx,
+            stricter_abi_and_runtime_constraints,
+            direct_mapping,
+            mask_out_rent_epoch_in_vm_serialization,
+        )
+        .expect("invariant violation: serialize_parameters failed");
 
     let mut config = environments.program_runtime_v1.get_config().clone();
     config.enable_register_tracing = true;

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -261,26 +261,8 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
                 return Some(SyscallEffects {
                     error,
                     error_kind: crate::proto::ErrKind::Instruction as i32,
-                    r0: 0,
-                    r1: 0,
-                    r2: 0,
-                    r3: 0,
-                    r4: 0,
-                    r5: 0,
-                    r6: 0,
-                    r7: 0,
-                    r8: 0,
-                    r9: 0,
-                    r10: 0,
                     cu_avail: invoke_ctx.get_remaining(),
-                    heap: vec![],
-                    stack: vec![],
-                    input_data_regions: vec![],
-                    inputdata: vec![],
-                    rodata: vec![],
-                    frame_count: 0,
-                    log: vec![],
-                    pc: 0,
+                    ..Default::default()
                 });
             }
         };

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -175,26 +175,14 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         ),
     );
 
-    let Some(program_idx) = invoke_ctx
+    let program_idx = invoke_ctx
         .transaction_context
         .find_index_of_account(&program_id)
-    else {
-        // Skip test if program_id not found in accounts
-        cleanup_static_ptrs(
-            transaction_context_ptr,
-            sysvar_cache_ptr,
-            program_cache_for_tx_batch_ptr,
-            runtime_features_ptr,
-            instr_ctx_ptr,
-            callback_context_ptr,
-            environments_ptr,
-        );
-        return None;
-    };
-    if program_idx > 255 {
-        // TransactionContext::configure_next_instruction_for_tests() crashes if program_idx > 255
-        return None;
-    }
+        .expect("invariant violation: program_id must be found in accounts");
+    assert!(
+        program_idx <= 255,
+        "invariant violation: program_idx must be <= 255"
+    );
     let direct_mapping = invoke_ctx.get_feature_set().account_data_direct_mapping;
     let stricter_abi_and_runtime_constraints = invoke_ctx
         .get_feature_set()

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -236,53 +236,23 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     //   3. heap
     //   4. input data aka accounts
     // The stack gap size is 0 iff direct mapping is enabled.
-    let serialize_result = serialize_parameters(
-        &caller_instr_ctx,
-        stricter_abi_and_runtime_constraints,
-        direct_mapping,
-        mask_out_rent_epoch_in_vm_serialization,
-    );
-
+    // serialize_parameters should never fail - the fuzzer now ensures
+    // valid instruction account counts, so unwrap is safe here
     let (_aligned_memory, input_memory_regions, acc_metadatas, _instruction_data_offset) =
-        match serialize_result {
-            Ok(result) => result,
-            Err(e) => {
-                // Return effects with the serialization error instead of rejecting
-                let error = crate::utils::err_map::instr_err_to_num(&e) as i64;
-                cleanup_static_ptrs(
-                    transaction_context_ptr,
-                    sysvar_cache_ptr,
-                    program_cache_for_tx_batch_ptr,
-                    runtime_features_ptr,
-                    instr_ctx_ptr,
-                    callback_context_ptr,
-                    environments_ptr,
-                );
-                return Some(SyscallEffects {
-                    error,
-                    error_kind: crate::proto::ErrKind::Instruction as i32,
-                    cu_avail: invoke_ctx.get_remaining(),
-                    ..Default::default()
-                });
-            }
-        };
+        serialize_parameters(
+            &caller_instr_ctx,
+            stricter_abi_and_runtime_constraints,
+            direct_mapping,
+            mask_out_rent_epoch_in_vm_serialization,
+        )
+        .expect("invariant violation: serialize_parameters failed");
 
     let sbpf_version = SBPFVersion::V0;
 
     // Set up memory mapping
-    let Some(vm_ctx) = input.vm_ctx else {
-        // Match FD behavior: skip test if vm_ctx is missing
-        cleanup_static_ptrs(
-            transaction_context_ptr,
-            sysvar_cache_ptr,
-            program_cache_for_tx_batch_ptr,
-            runtime_features_ptr,
-            instr_ctx_ptr,
-            callback_context_ptr,
-            environments_ptr,
-        );
-        return None;
-    };
+    let vm_ctx = input
+        .vm_ctx
+        .expect("invariant violation: vm_ctx must be present for every execution");
     // Follow FD harness behavior
     if vm_ctx.heap_max as usize > HEAP_MAX {
         cleanup_static_ptrs(

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -179,6 +179,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         .transaction_context
         .find_index_of_account(&program_id)
     else {
+        // Skip test if program_id not found in accounts
         cleanup_static_ptrs(
             transaction_context_ptr,
             sysvar_cache_ptr,
@@ -235,19 +236,71 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     //   3. heap
     //   4. input data aka accounts
     // The stack gap size is 0 iff direct mapping is enabled.
+    let serialize_result = serialize_parameters(
+        &caller_instr_ctx,
+        stricter_abi_and_runtime_constraints,
+        direct_mapping,
+        mask_out_rent_epoch_in_vm_serialization,
+    );
+
     let (_aligned_memory, input_memory_regions, acc_metadatas, _instruction_data_offset) =
-        serialize_parameters(
-            &caller_instr_ctx,
-            stricter_abi_and_runtime_constraints,
-            direct_mapping,
-            mask_out_rent_epoch_in_vm_serialization,
-        )
-        .unwrap();
+        match serialize_result {
+            Ok(result) => result,
+            Err(e) => {
+                // Return effects with the serialization error instead of rejecting
+                let error = crate::utils::err_map::instr_err_to_num(&e) as i64;
+                cleanup_static_ptrs(
+                    transaction_context_ptr,
+                    sysvar_cache_ptr,
+                    program_cache_for_tx_batch_ptr,
+                    runtime_features_ptr,
+                    instr_ctx_ptr,
+                    callback_context_ptr,
+                    environments_ptr,
+                );
+                return Some(SyscallEffects {
+                    error,
+                    error_kind: crate::proto::ErrKind::Instruction as i32,
+                    r0: 0,
+                    r1: 0,
+                    r2: 0,
+                    r3: 0,
+                    r4: 0,
+                    r5: 0,
+                    r6: 0,
+                    r7: 0,
+                    r8: 0,
+                    r9: 0,
+                    r10: 0,
+                    cu_avail: invoke_ctx.get_remaining(),
+                    heap: vec![],
+                    stack: vec![],
+                    input_data_regions: vec![],
+                    inputdata: vec![],
+                    rodata: vec![],
+                    frame_count: 0,
+                    log: vec![],
+                    pc: 0,
+                });
+            }
+        };
 
     let sbpf_version = SBPFVersion::V0;
 
     // Set up memory mapping
-    let vm_ctx = input.vm_ctx.unwrap();
+    let Some(vm_ctx) = input.vm_ctx else {
+        // Match FD behavior: skip test if vm_ctx is missing
+        cleanup_static_ptrs(
+            transaction_context_ptr,
+            sysvar_cache_ptr,
+            program_cache_for_tx_batch_ptr,
+            runtime_features_ptr,
+            instr_ctx_ptr,
+            callback_context_ptr,
+            environments_ptr,
+        );
+        return None;
+    };
     // Follow FD harness behavior
     if vm_ctx.heap_max as usize > HEAP_MAX {
         cleanup_static_ptrs(


### PR DESCRIPTION
Return proper error effects instead of panicking or skipping silently:

- `serialize_parameters()` failures now return `SyscallEffects` with the actual error code instead of `.unwrap()` panic
- `vm_ctx` missing case returns `None` (skip) instead of panic
- error codes mapped via `instr_err_to_num()` to match FD behavior

Prerequisite FD harness PR: https://github.com/firedancer-io/firedancer/pull/8005