### PR TITLE
fix: use release-with-debug profile for hfuzz and nightly toolchain for coverage builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,13 +49,18 @@ shared_obj:
 	RUSTFLAGS="$(RUSTFLAGS)" $(CARGO) build --target x86_64-unknown-linux-gnu --release --lib
 
 shared_obj_hfuzz:
-	RUSTFLAGS="$(RUSTFLAGS_HFUZZ)" $(CARGO) build --target x86_64-unknown-linux-gnu --release --lib --target-dir target/hfuzz
+	RUSTFLAGS="$(RUSTFLAGS_HFUZZ)" $(CARGO) build --target x86_64-unknown-linux-gnu --profile release-with-debug --lib --target-dir target/hfuzz
 
 shared_obj_pcguard:
 	RUSTFLAGS="$(RUSTFLAGS_PCGUARD)" $(CARGO) build --target x86_64-unknown-linux-gnu --release --lib --target-dir target/pcguard
 
 shared_obj_cov:
-	RUSTFLAGS="$(RUSTFLAGS) -Cinstrument-coverage" $(CARGO) build --target x86_64-unknown-linux-gnu --release \
+	@# Build the coverage SO with Rust nightly to get a newer LLVM.
+	@# Stable 1.86 ships LLVM 19 whose llvm-cov chokes on large Rust
+	@# binaries ("function name is empty").  Nightly ships LLVM 22+
+	@# which fixes that bug.  Only the +cov.so is built with nightly;
+	@# the regular and hfuzz builds remain on the pinned stable channel.
+	RUSTFLAGS="$(RUSTFLAGS) -Cinstrument-coverage" $(CARGO) +nightly build --target x86_64-unknown-linux-gnu --release \
 	 --lib --target-dir target/cov
 
 	# to avoid conflicts when uploading as GH artifact


### PR DESCRIPTION
Switches `shared_obj_hfuzz` to the release-with-debug profile to preserve debug symbols needed for live in-process coverage analysis, and switches `shared_obj_cov` to `cargo +nightly` to work around a known LLVM 19 bug in stable Rust 1.86 where `llvm-cov` chokes on large binaries with "function name is empty", blocking the generation of useable Rust LLVM code coverage reports for Agave. As expected, the `shared_obj_cov` target now requires the Rust nightly toolchain to be installed. Once Agave upgrades to an LLVM 20+ toolchain, we can switch back to non-nightly for the coverage target.

Note that fuzzing still takes place against the non-nightly binary target, the nightly shared object is only used for offline post-hoc code coverage report generation.