### PR TITLE
firedancer-io/agave `cargo test` has a broken build, fix it

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build agave upstream tests
         run: |
-          # Build test binaries for the agave crates we link against.
+          # Build test binaries for all agave workspace crates.
           # This catches compilation errors (e.g. missing args, API changes)
           # that only surface when building tests in the upstream checkout.
           AGAVE_REV=$(grep -A2 'name = "agave-feature-set"' Cargo.lock \
@@ -69,38 +69,7 @@ jobs:
           if [ -d "$AGAVE_CHECKOUT" ]; then
             echo "Building agave tests in $AGAVE_CHECKOUT"
             pushd "$AGAVE_CHECKOUT"
-            cargo test --release --no-run \
-              -p solana-runtime \
-              -p solana-accounts-db \
-              -p solana-svm \
-              -p solana-program-runtime \
-              -p solana-bpf-loader-program \
-              -p solana-compute-budget-program \
-              -p solana-system-program \
-              -p solana-vote-program \
-              -p solana-loader-v4-program \
-              -p solana-zk-elgamal-proof-program \
-              -p solana-entry \
-              -p solana-gossip \
-              -p solana-ledger \
-              -p solana-transaction-context \
-              -p solana-vote \
-              -p solana-lattice-hash \
-              -p solana-cost-model \
-              -p solana-core \
-              -p solana-poh \
-              -p solana-streamer \
-              -p solana-bloom \
-              -p solana-bucket-map \
-              -p solana-merkle-tree \
-              -p solana-perf \
-              -p solana-rpc \
-              -p solana-runtime-transaction \
-              -p solana-unified-scheduler-logic \
-              -p solana-unified-scheduler-pool \
-              -p agave-feature-set \
-              -p agave-syscalls \
-              -p agave-precompiles
+            cargo test --release --no-run --workspace
             popd
           else
             echo "::error::Agave checkout not found for rev $AGAVE_REV"

--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -70,8 +70,37 @@ jobs:
             echo "Building agave tests in $AGAVE_CHECKOUT"
             pushd "$AGAVE_CHECKOUT"
             cargo test --release --no-run \
-              --workspace \
-              --exclude solana-test-validator
+              -p solana-runtime \
+              -p solana-accounts-db \
+              -p solana-svm \
+              -p solana-program-runtime \
+              -p solana-bpf-loader-program \
+              -p solana-compute-budget-program \
+              -p solana-system-program \
+              -p solana-vote-program \
+              -p solana-loader-v4-program \
+              -p solana-zk-elgamal-proof-program \
+              -p solana-entry \
+              -p solana-gossip \
+              -p solana-ledger \
+              -p solana-transaction-context \
+              -p solana-vote \
+              -p solana-lattice-hash \
+              -p solana-cost-model \
+              -p solana-core \
+              -p solana-poh \
+              -p solana-streamer \
+              -p solana-bloom \
+              -p solana-bucket-map \
+              -p solana-merkle-tree \
+              -p solana-perf \
+              -p solana-rpc \
+              -p solana-runtime-transaction \
+              -p solana-unified-scheduler-logic \
+              -p solana-unified-scheduler-pool \
+              -p agave-feature-set \
+              -p agave-syscalls \
+              -p agave-precompiles
             popd
           else
             echo "::error::Agave checkout not found for rev $AGAVE_REV"

--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -57,6 +57,27 @@ jobs:
           cargo check --release
           cargo test --release
 
+      - name: Build agave upstream tests
+        run: |
+          # Build test binaries for the agave crates we link against.
+          # This catches compilation errors (e.g. missing args, API changes)
+          # that only surface when building tests in the upstream checkout.
+          AGAVE_REV=$(grep -A2 'name = "agave-feature-set"' Cargo.lock \
+              | grep -oP '#\K[0-9a-f]+' | head -c7)
+          AGAVE_CHECKOUT=$(find ~/.cargo/git/checkouts/ -maxdepth 2 -type d \
+              -path "*agave*/$AGAVE_REV" | head -1)
+          if [ -d "$AGAVE_CHECKOUT" ]; then
+            echo "Building agave tests in $AGAVE_CHECKOUT"
+            pushd "$AGAVE_CHECKOUT"
+            cargo test --release --no-run \
+              --workspace \
+              --exclude solana-test-validator
+            popd
+          else
+            echo "::error::Agave checkout not found for rev $AGAVE_REV"
+            exit 1
+          fi
+
       - name: Build shared objects
         if: ${{ inputs.upload_artifacts }}
         run: make shared_obj

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 [[package]]
 name = "agave-bls-cert-verify"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-votor-messages",
  "bitvec",
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 name = "agave-bls12-381"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "blst",
  "blstrs",
@@ -86,7 +86,7 @@ dependencies = [
 [[package]]
 name = "agave-feature-set"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule",
@@ -100,7 +100,7 @@ dependencies = [
 [[package]]
 name = "agave-fs"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "agave-io-uring"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "io-uring",
  "libc",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "agave-logger"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "env_logger",
  "libc",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "agave-precompiles"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -158,7 +158,7 @@ dependencies = [
 [[package]]
 name = "agave-random"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "rand 0.9.2",
 ]
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 name = "agave-reserved-account-keys"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey 4.1.0",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "agave-snapshots"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-fs",
  "bincode",
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "agave-syscalls"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-bls12-381",
  "bincode",
@@ -248,7 +248,7 @@ dependencies = [
 [[package]]
 name = "agave-transaction-view"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "solana-hash 4.2.0",
  "solana-message",
@@ -264,7 +264,7 @@ dependencies = [
 [[package]]
 name = "agave-votor-messages"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -5504,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5545,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder-client-types"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5570,7 +5570,7 @@ dependencies = [
 [[package]]
 name = "solana-accounts-db"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-fs",
  "ahash 0.8.12",
@@ -5736,7 +5736,7 @@ dependencies = [
 [[package]]
 name = "solana-bloom"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "bv",
  "fnv",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -5826,7 +5826,7 @@ dependencies = [
 [[package]]
 name = "solana-bucket-map"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "ahash 0.8.12",
  "bv",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -5864,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins-default-costs"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -5881,7 +5881,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6012,7 +6012,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -6021,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-instruction"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -6052,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -6077,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "solana-connection-cache"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6099,7 +6099,7 @@ dependencies = [
 [[package]]
 name = "solana-cost-model"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -6212,7 +6212,7 @@ dependencies = [
 [[package]]
 name = "solana-download-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -6237,7 +6237,7 @@ dependencies = [
 [[package]]
 name = "solana-entry"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-votor-messages",
  "bincode",
@@ -6338,7 +6338,7 @@ dependencies = [
 [[package]]
 name = "solana-fee"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -6410,7 +6410,7 @@ dependencies = [
 [[package]]
 name = "solana-genesis-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -6424,7 +6424,7 @@ dependencies = [
 [[package]]
 name = "solana-gossip"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -6635,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "solana-lattice-hash"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6646,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "solana-leader-schedule"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-random",
  "itertools 0.14.0",
@@ -6659,7 +6659,7 @@ dependencies = [
 [[package]]
 name = "solana-ledger"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "agave-random",
@@ -6805,7 +6805,7 @@ dependencies = [
 [[package]]
 name = "solana-loader-v4-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "log",
  "solana-account",
@@ -6828,12 +6828,12 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 
 [[package]]
 name = "solana-merkle-tree"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "fast-math",
  "solana-hash 4.2.0",
@@ -6863,7 +6863,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6893,7 +6893,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 [[package]]
 name = "solana-net-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6986,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -7115,7 +7115,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7198,7 +7198,7 @@ dependencies = [
 [[package]]
 name = "solana-pubsub-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -7223,7 +7223,7 @@ dependencies = [
 [[package]]
 name = "solana-quic-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -7251,7 +7251,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "log",
  "num_cpus",
@@ -7260,7 +7260,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "console 0.16.3",
  "dialoguer",
@@ -7314,7 +7314,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-api"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -7373,7 +7373,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-nonce-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7389,7 +7389,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-types"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7415,7 +7415,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-bls-cert-verify",
  "agave-feature-set",
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime-transaction"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7854,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-bigtable"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -7894,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-proto"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "bincode",
  "bs58",
@@ -7919,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -7964,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -8007,7 +8007,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-callback"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -8018,12 +8018,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-feature-set"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 
 [[package]]
 name = "solana-svm-log-collector"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "log",
 ]
@@ -8031,12 +8031,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-measure"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 
 [[package]]
 name = "solana-svm-timings"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -8046,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-transaction"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "solana-hash 4.2.0",
  "solana-message",
@@ -8059,7 +8059,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-type-overrides"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "rand 0.9.2",
 ]
@@ -8097,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "solana-system-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "bincode",
  "log",
@@ -8185,7 +8185,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 [[package]]
 name = "solana-tls-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "rustls 0.23.37",
  "solana-keypair",
@@ -8197,7 +8197,7 @@ dependencies = [
 [[package]]
 name = "solana-tpu-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8251,7 +8251,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -8280,7 +8280,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-metrics-tracker"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8295,7 +8295,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -8337,7 +8337,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status-client-types"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8360,7 +8360,7 @@ dependencies = [
 [[package]]
 name = "solana-udp-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -8375,7 +8375,7 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-logic"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "assert_matches",
  "solana-clock",
@@ -8389,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "solana-version"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "rand 0.9.2",
@@ -8402,7 +8402,7 @@ dependencies = [
 [[package]]
 name = "solana-vote"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -8456,7 +8456,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8499,7 +8499,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-elgamal-proof-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -8586,7 +8586,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-proof-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
+source = "git+https://github.com/firedancer-io/agave?rev=c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8#c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8"
 dependencies = [
  "solana-program-runtime",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -36,7 +36,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -358,27 +358,12 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -388,18 +373,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -452,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -968,7 +944,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
 ]
@@ -1012,17 +988,17 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
- "digest 0.10.7",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1041,6 +1017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1073,19 +1058,20 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -1211,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1288,7 +1274,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1319,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.61"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fa72306bb30daf11bc97773431628e5b4916e97aaa74b7d3f625d4d495da02"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1329,11 +1315,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.61"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2071365c5c56eae7d77414029dde2f4f4ba151cf68d5a3261c9a40de428ace93"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
@@ -1341,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.61"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec5be1eea072311774b7b84ded287adbd9f293f9d23456817605c6042f4f5e0"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1353,15 +1339,21 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e78417baa3b3114dc0e95e7357389a249c4da97c3c2b540700079db6171bfd7"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmov"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1428,13 +1420,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
@@ -1482,6 +1473,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1559,6 +1559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1584,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1597,7 +1615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1625,8 +1643,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1644,12 +1672,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1731,7 +1783,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console 0.16.2",
+ "console 0.16.3",
  "shell-words",
  "tempfile",
  "zeroize",
@@ -1754,8 +1806,19 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1972,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -1982,11 +2045,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
@@ -2112,7 +2175,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -2130,7 +2193,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -2677,6 +2740,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a79f2aff40c18ab8615ddc5caa9eb5b96314aef18fe5823090f204ad988e813"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3028,7 +3100,7 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console 0.16.2",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width 0.2.2",
  "unit-prefix",
@@ -3072,9 +3144,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -3124,9 +3196,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -3161,7 +3233,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine 4.6.7",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -3170,9 +3242,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -3186,10 +3280,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -3229,7 +3325,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3273,9 +3369,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -3534,9 +3630,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -3689,9 +3785,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -3757,9 +3853,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -3767,9 +3863,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4057,7 +4153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4070,9 +4166,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -4369,7 +4465,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -4390,7 +4486,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -4862,9 +4958,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4931,7 +5027,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -4981,7 +5077,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -5006,9 +5102,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5189,9 +5285,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "serde_core",
  "serde_with_macros",
@@ -5199,11 +5295,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5216,7 +5312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -5228,7 +5324,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -5240,7 +5336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -5310,9 +5406,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simpl"
@@ -5469,9 +5565,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-info"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3397241392f5756925029acaa8515dc70fcbe3d8059d4885d7d6533baf64fd"
+checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
  "solana-address 2.3.0",
  "solana-program-error",
@@ -5699,9 +5795,9 @@ dependencies = [
 
 [[package]]
 name = "solana-borsh"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4a37fc44f0633779a619840b5117c2a895996cec57eb3dc10597fac7867875"
+checksum = "c04abbae16f57178a163125805637b8a076175bb5c0002fb04f4792bea901cf7"
 dependencies = [
  "borsh",
 ]
@@ -6050,9 +6146,9 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "3.1.10"
+version = "3.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d7e1177e6006823b91e0a930d94992ed74f8a6327d54ee50a9457ff72e625a"
+checksum = "9a9eaec815ed773919bc7269c027933fc2472d7b9876f68ea6f1281c7daa5278"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -6458,12 +6554,11 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a6d22d0a6fdf345be294bb9afdcd40c296cdc095e64e7ceaa3bb3c2f608c1c"
+checksum = "a97881335fc698deb46c6571945969aae6d93a14e2fff792a368b4fac872f116"
 dependencies = [
  "bincode",
- "borsh",
  "serde",
  "serde_derive",
  "solana-define-syscall 5.0.0",
@@ -6993,9 +7088,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-error"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1af32c995a7b692a915bb7414d5f8e838450cf7c70414e763d8abcae7b51f28"
+checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
 dependencies = [
  "borsh",
 ]
@@ -7011,9 +7106,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-option"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362279f6e8020e4cf11313233789bf619420ad8835ebc91963ee5cec91bb05da"
+checksum = "7a88006a9b8594088cec9027ab77caaaa258a2aaa2083d3f086c44b42e50aeab"
 
 [[package]]
 name = "solana-program-pack"
@@ -7174,7 +7269,7 @@ name = "solana-remote-wallet"
 version = "4.0.0-beta.5"
 source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
- "console 0.16.2",
+ "console 0.16.3",
  "dialoguer",
  "log",
  "num-derive",
@@ -8399,6 +8494,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-zero-copy"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f52dd8f733a13f6a18e55de83cf97c4c3f5fdf27ea3830bcff0b35313efcc2"
+dependencies = [
+ "bytemuck",
+ "bytemuck_derive",
+]
+
+[[package]]
 name = "solana-zk-elgamal-proof-program"
 version = "4.0.0-beta.5"
 source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
@@ -8504,7 +8609,7 @@ dependencies = [
  "agave-votor-messages",
  "ahash 0.8.12",
  "bincode",
- "clap 4.5.61",
+ "clap 4.6.0",
  "five8_core 1.0.0",
  "flatbuffers",
  "flatc-rust",
@@ -8608,9 +8713,9 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48cc11459e265d5b501534144266620289720b4c44522a47bc6b63cd295d2f3"
+checksum = "e597c5ff9ed7c74a54dbc47bae2f06e4db8c98f4356ad280200dc11878266db1"
 dependencies = [
  "bytemuck",
  "solana-program-error",
@@ -8717,7 +8822,7 @@ checksum = "879a9ebad0d77383d3ea71e7de50503554961ff0f4ef6cbca39ad126e6f6da3a"
 dependencies = [
  "bytemuck",
  "solana-account-info",
- "solana-curve25519 3.1.10",
+ "solana-curve25519 3.1.11",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-msg",
@@ -8799,19 +8904,18 @@ dependencies = [
 
 [[package]]
 name = "spl-type-length-value"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca20a1a19f4507a98ca4b28ff5ed54cac9b9d34ed27863e2bde50a3238f9a6ac"
+checksum = "2504631748c48d2a937414d64a12dcac4588d34bd07d355d648619c189d29435"
 dependencies = [
  "bytemuck",
  "num-derive",
  "num-traits",
  "num_enum",
  "solana-account-info",
- "solana-msg",
  "solana-program-error",
+ "solana-zero-copy",
  "spl-discriminator",
- "spl-pod",
  "thiserror 2.0.18",
 ]
 
@@ -9095,9 +9199,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -9219,18 +9323,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap 2.13.0",
  "toml_datetime",
@@ -9240,9 +9344,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow",
 ]
@@ -9490,7 +9594,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -9630,9 +9734,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9643,23 +9747,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9667,9 +9767,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9680,9 +9780,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
@@ -9723,9 +9823,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9831,7 +9931,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fca057fc9a13dd19cdb64ef558635d43c42667c0afa1ae7915ea1fa66993fd1a"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10195,9 +10295,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -10367,18 +10467,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 [[package]]
 name = "agave-bls-cert-verify"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-votor-messages",
  "bitvec",
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 name = "agave-bls12-381"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "blst",
  "blstrs",
@@ -86,7 +86,7 @@ dependencies = [
 [[package]]
 name = "agave-feature-set"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule",
@@ -100,7 +100,7 @@ dependencies = [
 [[package]]
 name = "agave-fs"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "agave-io-uring"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "io-uring",
  "libc",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "agave-logger"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "env_logger",
  "libc",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "agave-precompiles"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -158,7 +158,7 @@ dependencies = [
 [[package]]
 name = "agave-random"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "rand 0.9.2",
 ]
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 name = "agave-reserved-account-keys"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey 4.1.0",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "agave-snapshots"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-fs",
  "bincode",
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "agave-syscalls"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-bls12-381",
  "bincode",
@@ -248,7 +248,7 @@ dependencies = [
 [[package]]
 name = "agave-transaction-view"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "solana-hash 4.2.0",
  "solana-message",
@@ -264,7 +264,7 @@ dependencies = [
 [[package]]
 name = "agave-votor-messages"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -5415,7 +5415,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5456,7 +5456,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder-client-types"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5481,7 +5481,7 @@ dependencies = [
 [[package]]
 name = "solana-accounts-db"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-fs",
  "ahash 0.8.12",
@@ -5647,7 +5647,7 @@ dependencies = [
 [[package]]
 name = "solana-bloom"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "bv",
  "fnv",
@@ -5709,7 +5709,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -5737,7 +5737,7 @@ dependencies = [
 [[package]]
 name = "solana-bucket-map"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "ahash 0.8.12",
  "bv",
@@ -5756,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -5775,7 +5775,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins-default-costs"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -5792,7 +5792,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -5821,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5923,7 +5923,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -5932,7 +5932,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-instruction"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -5963,7 +5963,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -5988,7 +5988,7 @@ dependencies = [
 [[package]]
 name = "solana-connection-cache"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6010,7 +6010,7 @@ dependencies = [
 [[package]]
 name = "solana-cost-model"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -6123,7 +6123,7 @@ dependencies = [
 [[package]]
 name = "solana-download-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -6148,7 +6148,7 @@ dependencies = [
 [[package]]
 name = "solana-entry"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-votor-messages",
  "bincode",
@@ -6249,7 +6249,7 @@ dependencies = [
 [[package]]
 name = "solana-fee"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -6321,7 +6321,7 @@ dependencies = [
 [[package]]
 name = "solana-genesis-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -6335,7 +6335,7 @@ dependencies = [
 [[package]]
 name = "solana-gossip"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -6547,7 +6547,7 @@ dependencies = [
 [[package]]
 name = "solana-lattice-hash"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6558,7 +6558,7 @@ dependencies = [
 [[package]]
 name = "solana-leader-schedule"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-random",
  "itertools 0.14.0",
@@ -6571,7 +6571,7 @@ dependencies = [
 [[package]]
 name = "solana-ledger"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "agave-random",
@@ -6717,7 +6717,7 @@ dependencies = [
 [[package]]
 name = "solana-loader-v4-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "log",
  "solana-account",
@@ -6740,12 +6740,12 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 
 [[package]]
 name = "solana-merkle-tree"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "fast-math",
  "solana-hash 4.2.0",
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6805,7 +6805,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 [[package]]
 name = "solana-net-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6898,7 +6898,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -7027,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7110,7 +7110,7 @@ dependencies = [
 [[package]]
 name = "solana-pubsub-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -7135,7 +7135,7 @@ dependencies = [
 [[package]]
 name = "solana-quic-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "log",
  "num_cpus",
@@ -7172,7 +7172,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "console 0.16.2",
  "dialoguer",
@@ -7226,7 +7226,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7265,7 +7265,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-api"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -7285,7 +7285,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-nonce-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7301,7 +7301,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-types"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7327,7 +7327,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-bls-cert-verify",
  "agave-feature-set",
@@ -7467,7 +7467,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime-transaction"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7766,7 +7766,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-bigtable"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -7806,7 +7806,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-proto"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "bincode",
  "bs58",
@@ -7831,7 +7831,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -7876,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -7919,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-callback"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -7930,12 +7930,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-feature-set"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 
 [[package]]
 name = "solana-svm-log-collector"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "log",
 ]
@@ -7943,12 +7943,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-measure"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 
 [[package]]
 name = "solana-svm-timings"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -7958,7 +7958,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-transaction"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "solana-hash 4.2.0",
  "solana-message",
@@ -7971,7 +7971,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-type-overrides"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "rand 0.9.2",
 ]
@@ -8009,7 +8009,7 @@ dependencies = [
 [[package]]
 name = "solana-system-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "bincode",
  "log",
@@ -8097,7 +8097,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 [[package]]
 name = "solana-tls-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "rustls 0.23.37",
  "solana-keypair",
@@ -8109,7 +8109,7 @@ dependencies = [
 [[package]]
 name = "solana-tpu-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8163,7 +8163,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-metrics-tracker"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8207,7 +8207,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -8249,7 +8249,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status-client-types"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8272,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "solana-udp-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-logic"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "assert_matches",
  "solana-clock",
@@ -8301,7 +8301,7 @@ dependencies = [
 [[package]]
 name = "solana-version"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "rand 0.9.2",
@@ -8314,7 +8314,7 @@ dependencies = [
 [[package]]
 name = "solana-vote"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -8368,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8401,7 +8401,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-elgamal-proof-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -8488,7 +8488,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-proof-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=ca1228f0892826281315ca7ca26ce30f8b2f3432#ca1228f0892826281315ca7ca26ce30f8b2f3432"
+source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -8505,6 +8505,7 @@ dependencies = [
  "ahash 0.8.12",
  "bincode",
  "clap 4.5.61",
+ "five8_core 1.0.0",
  "flatbuffers",
  "flatc-rust",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 [[package]]
 name = "agave-bls-cert-verify"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-votor-messages",
  "bitvec",
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 name = "agave-bls12-381"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "blst",
  "blstrs",
@@ -86,7 +86,7 @@ dependencies = [
 [[package]]
 name = "agave-feature-set"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule",
@@ -100,7 +100,7 @@ dependencies = [
 [[package]]
 name = "agave-fs"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-io-uring",
  "io-uring",
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "agave-io-uring"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "io-uring",
  "libc",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "agave-logger"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "env_logger",
  "libc",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "agave-precompiles"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -158,7 +158,7 @@ dependencies = [
 [[package]]
 name = "agave-random"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "rand 0.9.2",
 ]
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 name = "agave-reserved-account-keys"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey 4.1.0",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "agave-snapshots"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-fs",
  "bincode",
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "agave-syscalls"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-bls12-381",
  "bincode",
@@ -248,7 +248,7 @@ dependencies = [
 [[package]]
 name = "agave-transaction-view"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "solana-hash 4.2.0",
  "solana-message",
@@ -264,7 +264,7 @@ dependencies = [
 [[package]]
 name = "agave-votor-messages"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -2741,9 +2741,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a79f2aff40c18ab8615ddc5caa9eb5b96314aef18fe5823090f204ad988e813"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
@@ -2774,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2787,7 +2787,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2818,7 +2817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls 0.23.37",
  "rustls-pki-types",
@@ -2861,7 +2860,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2881,7 +2880,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -3280,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4119,12 +4118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4801,7 +4794,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -4841,7 +4834,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
@@ -5511,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5552,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder-client-types"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5577,7 +5570,7 @@ dependencies = [
 [[package]]
 name = "solana-accounts-db"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-fs",
  "ahash 0.8.12",
@@ -5743,7 +5736,7 @@ dependencies = [
 [[package]]
 name = "solana-bloom"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "bv",
  "fnv",
@@ -5805,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -5833,7 +5826,7 @@ dependencies = [
 [[package]]
 name = "solana-bucket-map"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "ahash 0.8.12",
  "bv",
@@ -5852,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -5871,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins-default-costs"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -5888,7 +5881,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -5917,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6019,7 +6012,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -6028,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-instruction"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -6059,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -6084,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "solana-connection-cache"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6106,7 +6099,7 @@ dependencies = [
 [[package]]
 name = "solana-cost-model"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -6219,7 +6212,7 @@ dependencies = [
 [[package]]
 name = "solana-download-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -6244,7 +6237,7 @@ dependencies = [
 [[package]]
 name = "solana-entry"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-votor-messages",
  "bincode",
@@ -6345,7 +6338,7 @@ dependencies = [
 [[package]]
 name = "solana-fee"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -6417,7 +6410,7 @@ dependencies = [
 [[package]]
 name = "solana-genesis-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-snapshots",
  "log",
@@ -6431,7 +6424,7 @@ dependencies = [
 [[package]]
 name = "solana-gossip"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
@@ -6642,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "solana-lattice-hash"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6653,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "solana-leader-schedule"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-random",
  "itertools 0.14.0",
@@ -6666,7 +6659,7 @@ dependencies = [
 [[package]]
 name = "solana-ledger"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "agave-random",
@@ -6812,7 +6805,7 @@ dependencies = [
 [[package]]
 name = "solana-loader-v4-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "log",
  "solana-account",
@@ -6835,12 +6828,12 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 
 [[package]]
 name = "solana-merkle-tree"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "fast-math",
  "solana-hash 4.2.0",
@@ -6870,7 +6863,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6900,7 +6893,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 [[package]]
 name = "solana-net-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6993,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -7122,7 +7115,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7205,7 +7198,7 @@ dependencies = [
 [[package]]
 name = "solana-pubsub-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -7230,7 +7223,7 @@ dependencies = [
 [[package]]
 name = "solana-quic-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -7258,7 +7251,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "log",
  "num_cpus",
@@ -7267,7 +7260,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "console 0.16.3",
  "dialoguer",
@@ -7321,7 +7314,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7360,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-api"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -7380,7 +7373,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-nonce-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7396,7 +7389,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-types"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7422,7 +7415,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-bls-cert-verify",
  "agave-feature-set",
@@ -7562,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime-transaction"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7861,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-bigtable"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -7901,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-proto"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "bincode",
  "bs58",
@@ -7926,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -7971,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -8014,7 +8007,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-callback"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -8025,12 +8018,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-feature-set"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 
 [[package]]
 name = "solana-svm-log-collector"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "log",
 ]
@@ -8038,12 +8031,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-measure"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 
 [[package]]
 name = "solana-svm-timings"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -8053,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-transaction"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "solana-hash 4.2.0",
  "solana-message",
@@ -8066,7 +8059,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-type-overrides"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "rand 0.9.2",
 ]
@@ -8104,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "solana-system-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "bincode",
  "log",
@@ -8192,7 +8185,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 [[package]]
 name = "solana-tls-utils"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "rustls 0.23.37",
  "solana-keypair",
@@ -8204,7 +8197,7 @@ dependencies = [
 [[package]]
 name = "solana-tpu-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8258,7 +8251,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -8287,7 +8280,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-metrics-tracker"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8302,7 +8295,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -8344,7 +8337,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status-client-types"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8367,7 +8360,7 @@ dependencies = [
 [[package]]
 name = "solana-udp-client"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -8382,7 +8375,7 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-logic"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "assert_matches",
  "solana-clock",
@@ -8396,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "solana-version"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "rand 0.9.2",
@@ -8409,7 +8402,7 @@ dependencies = [
 [[package]]
 name = "solana-vote"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -8463,7 +8456,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -8506,7 +8499,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-elgamal-proof-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -8593,7 +8586,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-proof-program"
 version = "4.0.0-beta.5"
-source = "git+https://github.com/firedancer-io/agave?rev=a2b9a782fe7df5a549452e08e40f17433eda9e6a#a2b9a782fe7df5a549452e08e40f17433eda9e6a"
+source = "git+https://github.com/firedancer-io/agave?rev=1209f391e6dd6bc503761513f13f3465df479b88#1209f391e6dd6bc503761513f13f3465df479b88"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -9323,18 +9316,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "da053d28fe57e2c9d21b48261e14e7b4c8b670b54d2c684847b91feaf4c7dac5"
 dependencies = [
  "indexmap 2.13.0",
  "toml_datetime",
@@ -9344,9 +9337,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
 dependencies = [
  "winnow",
 ]
@@ -9734,9 +9727,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "7dc0882f7b5bb01ae8c5215a1230832694481c1a4be062fd410e12ea3da5b631"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9747,9 +9740,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "19280959e2844181895ef62f065c63e0ca07ece4771b53d89bfdb967d97cbf05"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9757,9 +9750,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "75973d3066e01d035dbedaad2864c398df42f8dd7b1ea057c35b8407c015b537"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9767,9 +9760,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "91af5e4be765819e0bcfee7322c14374dc821e35e72fa663a830bbc7dc199eac"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9780,9 +9773,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
 dependencies = [
  "unicode-ident",
 ]
@@ -9823,9 +9816,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "749466a37ee189057f54748b200186b59a03417a117267baf3fd89cecc9fb837"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,7 +2112,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 1.0.0",
+ "five8_core 0.1.2",
 ]
 
 [[package]]
@@ -2130,7 +2130,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 1.0.0",
+ "five8_core 0.1.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,32 +48,32 @@ solana-zk-sdk = "5.0.1"
 solana-rent = { version = "=3.0.0", features = ["serde"] }
 
 # Enable dev-context-only-utils for Agave dependencies that need it
-agave-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-agave-syscalls = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
-agave-votor-messages = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-agave-precompiles = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-agave-logger = { git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"] }
-solana-runtime = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-accounts-db = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-entry = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-lattice-hash = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-ledger = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-svm = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-vote = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-transaction-context = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]}
-solana-vote-program = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-compute-budget = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-program-runtime = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-svm-callback = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-svm-log-collector = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-svm-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-svm-timings = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-bpf-loader-program = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
-solana-loader-v4-program = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
-solana-compute-budget-program = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-system-program = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-zk-elgamal-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-gossip = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+agave-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+agave-syscalls = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
+agave-votor-messages = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+agave-precompiles = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+agave-logger = { git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"] }
+solana-runtime = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-accounts-db = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-entry = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-lattice-hash = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-ledger = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-svm = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-vote = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-transaction-context = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]}
+solana-vote-program = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-compute-budget = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-program-runtime = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-svm-callback = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-svm-log-collector = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-svm-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-svm-timings = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-bpf-loader-program = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
+solana-loader-v4-program = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
+solana-compute-budget-program = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-system-program = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-zk-elgamal-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-gossip = {git = "https://github.com/firedancer-io/agave", rev = "c9a99c3f5c1bc1db802195ec5acb2b7a9f3854e8", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
 solana-sanitize = "3.0.1"
 five8_core = "=1.0.0"  # Pin to 1.0.0 — five8 1.0.0 incorrectly allows 0.1.2 which lacks core::error::Error impl
 solana-sbpf = {git = "https://github.com/firedancer-io/sbpf", branch = "sbpf-v0.14.4-patches", version = "=0.14.4", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,32 +48,32 @@ solana-zk-sdk = "5.0.1"
 solana-rent = { version = "=3.0.0", features = ["serde"] }
 
 # Enable dev-context-only-utils for Agave dependencies that need it
-agave-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-agave-syscalls = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
-agave-votor-messages = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-agave-precompiles = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-agave-logger = { git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"] }
-solana-runtime = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-accounts-db = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-entry = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-lattice-hash = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-ledger = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-svm = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-vote = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-transaction-context = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]}
-solana-vote-program = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-compute-budget = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-program-runtime = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-svm-callback = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-svm-log-collector = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-svm-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-svm-timings = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-bpf-loader-program = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
-solana-loader-v4-program = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
-solana-compute-budget-program = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-system-program = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-zk-elgamal-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-gossip = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+agave-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+agave-syscalls = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
+agave-votor-messages = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+agave-precompiles = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+agave-logger = { git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"] }
+solana-runtime = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-accounts-db = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-entry = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-lattice-hash = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-ledger = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-svm = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-vote = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-transaction-context = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]}
+solana-vote-program = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-compute-budget = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-program-runtime = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-svm-callback = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-svm-log-collector = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-svm-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-svm-timings = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-bpf-loader-program = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
+solana-loader-v4-program = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
+solana-compute-budget-program = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-system-program = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-zk-elgamal-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-gossip = {git = "https://github.com/firedancer-io/agave", rev = "1209f391e6dd6bc503761513f13f3465df479b88", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
 solana-sanitize = "3.0.1"
 five8_core = "=1.0.0"  # Pin to 1.0.0 — five8 1.0.0 incorrectly allows 0.1.2 which lacks core::error::Error impl
 solana-sbpf = {git = "https://github.com/firedancer-io/sbpf", branch = "sbpf-v0.14.4-patches", version = "=0.14.4", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,33 +48,34 @@ solana-zk-sdk = "5.0.1"
 solana-rent = { version = "=3.0.0", features = ["serde"] }
 
 # Enable dev-context-only-utils for Agave dependencies that need it
-agave-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-agave-syscalls = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
-agave-votor-messages = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-agave-precompiles = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-agave-logger = { git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"] }
-solana-runtime = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-accounts-db = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-entry = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-lattice-hash = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-ledger = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-svm = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-vote = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-transaction-context = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]}
-solana-vote-program = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
-solana-compute-budget = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-program-runtime = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-svm-callback = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-svm-log-collector = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-svm-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-svm-timings = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-bpf-loader-program = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
-solana-loader-v4-program = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
-solana-compute-budget-program = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-system-program = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-zk-elgamal-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
-solana-gossip = {git = "https://github.com/firedancer-io/agave", rev = "ca1228f0892826281315ca7ca26ce30f8b2f3432", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+agave-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+agave-syscalls = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
+agave-votor-messages = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+agave-precompiles = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+agave-logger = { git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"] }
+solana-runtime = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-accounts-db = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-entry = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-lattice-hash = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-ledger = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-svm = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-vote = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-transaction-context = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]}
+solana-vote-program = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api", "dev-context-only-utils"]}
+solana-compute-budget = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-program-runtime = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-svm-callback = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-svm-log-collector = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-svm-feature-set = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-svm-timings = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-bpf-loader-program = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
+solana-loader-v4-program = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", default-features = false, features = ["agave-unstable-api"]}
+solana-compute-budget-program = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-system-program = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-zk-elgamal-proof-program = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
+solana-gossip = {git = "https://github.com/firedancer-io/agave", rev = "a2b9a782fe7df5a549452e08e40f17433eda9e6a", version = "=4.0.0-beta.5", features = ["agave-unstable-api"]}
 solana-sanitize = "3.0.1"
+five8_core = "=1.0.0"  # Pin to 1.0.0 — five8 1.0.0 incorrectly allows 0.1.2 which lacks core::error::Error impl
 solana-sbpf = {git = "https://github.com/firedancer-io/sbpf", branch = "sbpf-v0.14.4-patches", version = "=0.14.4", default-features = false}
 
 [lib]


### PR DESCRIPTION
- Updates agave pin from ca1228f to a2b9a78 which adds the missing feature_set argument to test_new_from_snapshot_uses_rent_from_sysvar.
- Pin five8_core=1.0.0 to fix solana-keypair compilation. The five8 1.0.0 crate incorrectly allows five8_core 0.1.2 which lacks the core::error::Error impl on DecodeError needed by solana-signature.
- Add Agave unit test build check to solfuzz-agave CI.