### PR TITLE
block: create feature gate accounts for all enabled feature gates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8427,6 +8427,7 @@ dependencies = [
  "solana-cost-model",
  "solana-entry",
  "solana-epoch-schedule",
+ "solana-feature-gate-interface",
  "solana-fee-calculator",
  "solana-gossip",
  "solana-hard-forks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ wincode = "=0.4.5"
 
 solana-account = "=3.4.0"
 solana-clock = "=3.0.1"
+solana-feature-gate-interface = { version = "=3.1.0", features = ["bincode"] }
 solana-epoch-schedule = "=3.0.0"
 solana-fee-calculator = "=3.1.0"
 solana-hard-forks = "=3.0.0"

--- a/src/block.rs
+++ b/src/block.rs
@@ -387,6 +387,10 @@ pub fn execute_block(context: BlockContext) -> Option<BlockEffects> {
         .map(|item| (item.address.as_slice(), item))
         .collect();
     let stake_history: StakeHistory = get_sysvar(&sysvar_accounts, stake_history::id().as_ref());
+    let rent: solana_rent::Rent = get_sysvar(
+        &sysvar_accounts,
+        solana_sdk_ids::sysvar::rent::id().as_ref(),
+    );
 
     let lamports_per_signature = bank_ctx.rbh_lamports_per_signature as u64;
 
@@ -397,13 +401,13 @@ pub fn execute_block(context: BlockContext) -> Option<BlockEffects> {
     let acct_states_from_proto = deserialize_accounts(&context.acct_states);
 
     /* Create feature gate accounts for all feature gates that are present in the protobuf
-       feature set.
+    feature set.
 
-       These feature gate accounts will be overriden by any account states that are already
-       present in the protobuf, so that it's obvious what the final account state is. */
+    These feature gate accounts will be overriden by any account states that are already
+    present in the protobuf, so that it's obvious what the final account state is. */
     let all_acct_state_pubkeys_from_proto: std::collections::HashSet<_> =
         acct_states_from_proto.iter().map(|(pk, _)| *pk).collect();
-    let accounts_to_store: Vec<_> = feature_accounts_from_protos(&fd_features)
+    let accounts_to_store: Vec<_> = feature_accounts_from_protos(&fd_features, &rent)
         .into_iter()
         .filter(|(pk, _)| !all_acct_state_pubkeys_from_proto.contains(pk))
         .chain(acct_states_from_proto)

--- a/src/block.rs
+++ b/src/block.rs
@@ -399,8 +399,8 @@ pub fn execute_block(context: BlockContext) -> Option<BlockEffects> {
     /* Create feature gate accounts for all feature gates that are present in the protobuf
        feature set.
 
-       Explicit account states from the protobuf overrides the feature gate accounts,
-       so that it's obvious what the final account state is. */
+       These feature gate accounts will be overriden by any account states that are already
+       present in the protobuf, so that it's obvious what the final account state is. */
     let all_acct_state_pubkeys_from_proto: std::collections::HashSet<_> =
         acct_states_from_proto.iter().map(|(pk, _)| *pk).collect();
     let accounts_to_store: Vec<_> = feature_accounts_from_protos(&fd_features)

--- a/src/block.rs
+++ b/src/block.rs
@@ -387,10 +387,6 @@ pub fn execute_block(context: BlockContext) -> Option<BlockEffects> {
         .map(|item| (item.address.as_slice(), item))
         .collect();
     let stake_history: StakeHistory = get_sysvar(&sysvar_accounts, stake_history::id().as_ref());
-    let rent: solana_rent::Rent = get_sysvar(
-        &sysvar_accounts,
-        solana_sdk_ids::sysvar::rent::id().as_ref(),
-    );
 
     let lamports_per_signature = bank_ctx.rbh_lamports_per_signature as u64;
 
@@ -407,7 +403,7 @@ pub fn execute_block(context: BlockContext) -> Option<BlockEffects> {
     present in the protobuf, so that it's obvious what the final account state is. */
     let all_acct_state_pubkeys_from_proto: std::collections::HashSet<_> =
         acct_states_from_proto.iter().map(|(pk, _)| *pk).collect();
-    let accounts_to_store: Vec<_> = feature_accounts_from_protos(&fd_features, &rent)
+    let accounts_to_store: Vec<_> = feature_accounts_from_protos(&fd_features)
         .into_iter()
         .filter(|(pk, _)| !all_acct_state_pubkeys_from_proto.contains(pk))
         .chain(acct_states_from_proto)

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,8 +1,8 @@
 use crate::utils::fd_hash::fd_hash;
 use crate::utils::program::common::{build_versioned_message, get_sysvar};
 use crate::utils::{
-    compute_accounts_data_size, create_accounts_db, deserialize_accounts, feature_set_from_protos,
-    restore_blockhash_queue,
+    compute_accounts_data_size, create_accounts_db, deserialize_accounts,
+    feature_accounts_from_protos, feature_set_from_protos, restore_blockhash_queue,
 };
 use agave_votor_messages::migration::MigrationStatus;
 use prost::Message;
@@ -394,7 +394,20 @@ pub fn execute_block(context: BlockContext) -> Option<BlockEffects> {
 
     /* Accounts DB config and initialization */
     let accounts = create_accounts_db(vec![]);
-    let accounts_to_store = deserialize_accounts(&context.acct_states);
+    let acct_states_from_proto = deserialize_accounts(&context.acct_states);
+
+    /* Create feature gate accounts for all feature gates that are present in the protobuf
+       feature set.
+
+       Explicit account states from the protobuf overrides the feature gate accounts,
+       so that it's obvious what the final account state is. */
+    let all_acct_state_pubkeys_from_proto: std::collections::HashSet<_> =
+        acct_states_from_proto.iter().map(|(pk, _)| *pk).collect();
+    let accounts_to_store: Vec<_> = feature_accounts_from_protos(&fd_features)
+        .into_iter()
+        .filter(|(pk, _)| !all_acct_state_pubkeys_from_proto.contains(pk))
+        .chain(acct_states_from_proto)
+        .collect();
 
     accounts.store_accounts_seq((parent_slot, &accounts_to_store[..]), None, None);
     accounts.store_accounts_seq((current_slot, &accounts_to_store[..]), None, None);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -51,6 +51,25 @@ pub fn feature_set_from_protos(input: &protos::FeatureSet) -> FeatureSet {
     feature_set
 }
 
+/// Create account state for each feature in the given feature set
+pub fn feature_accounts_from_protos(
+    input: &protos::FeatureSet,
+) -> Vec<(Pubkey, AccountSharedData)> {
+    let mut data = vec![0u8; 9];
+    data[0] = 1;
+
+    input
+        .features
+        .iter()
+        .filter_map(|id| INDEXED_FEATURES.get(id).copied())
+        .map(|pubkey| {
+            let mut account = AccountSharedData::new(1, data.len(), &solana_sdk_ids::feature::id());
+            account.set_data_from_slice(&data);
+            (pubkey, account)
+        })
+        .collect()
+}
+
 pub fn restore_blockhash_queue(entries: &[protos::BlockhashQueueEntry]) -> BlockhashQueue {
     let mut blockhash_queue = BlockhashQueue::default();
     entries.iter().for_each(|entry| {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -58,6 +58,8 @@ pub fn feature_accounts_from_protos(
     let feature = solana_feature_gate_interface::Feature {
         activated_at: Some(0),
     };
+    // Ensure all feature accounts are rent-exempt
+    const FEATURE_ACCOUNT_LAMPORTS: u64 = 100_000_000;
     input
         .features
         .iter()
@@ -65,7 +67,7 @@ pub fn feature_accounts_from_protos(
         .map(|pubkey| {
             (
                 pubkey,
-                solana_feature_gate_interface::create_account(&feature, 100_000_000),
+                solana_feature_gate_interface::create_account(&feature, FEATURE_ACCOUNT_LAMPORTS),
             )
         })
         .collect()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -51,22 +51,24 @@ pub fn feature_set_from_protos(input: &protos::FeatureSet) -> FeatureSet {
     feature_set
 }
 
-/// Create account state for each feature in the given feature set
+/// Create account state for each feature in the given feature set.
 pub fn feature_accounts_from_protos(
     input: &protos::FeatureSet,
+    rent: &solana_rent::Rent,
 ) -> Vec<(Pubkey, AccountSharedData)> {
-    // Feature { activated_at: Some(0) }
-    let mut data = vec![0u8; 9];
-    data[0] = 1;
-
+    let feature = solana_feature_gate_interface::Feature {
+        activated_at: Some(0),
+    };
+    let lamports = rent.minimum_balance(solana_feature_gate_interface::Feature::size_of());
     input
         .features
         .iter()
         .filter_map(|id| INDEXED_FEATURES.get(id).copied())
         .map(|pubkey| {
-            let mut account = AccountSharedData::new(1, data.len(), &solana_sdk_ids::feature::id());
-            account.set_data_from_slice(&data);
-            (pubkey, account)
+            (
+                pubkey,
+                solana_feature_gate_interface::create_account(&feature, lamports),
+            )
         })
         .collect()
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -55,6 +55,7 @@ pub fn feature_set_from_protos(input: &protos::FeatureSet) -> FeatureSet {
 pub fn feature_accounts_from_protos(
     input: &protos::FeatureSet,
 ) -> Vec<(Pubkey, AccountSharedData)> {
+    // Feature { activated_at: Some(0) }
     let mut data = vec![0u8; 9];
     data[0] = 1;
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -54,12 +54,10 @@ pub fn feature_set_from_protos(input: &protos::FeatureSet) -> FeatureSet {
 /// Create account state for each feature in the given feature set.
 pub fn feature_accounts_from_protos(
     input: &protos::FeatureSet,
-    rent: &solana_rent::Rent,
 ) -> Vec<(Pubkey, AccountSharedData)> {
     let feature = solana_feature_gate_interface::Feature {
         activated_at: Some(0),
     };
-    let lamports = rent.minimum_balance(solana_feature_gate_interface::Feature::size_of());
     input
         .features
         .iter()
@@ -67,7 +65,7 @@ pub fn feature_accounts_from_protos(
         .map(|pubkey| {
             (
                 pubkey,
-                solana_feature_gate_interface::create_account(&feature, lamports),
+                solana_feature_gate_interface::create_account(&feature, 100_000_000),
             )
         })
         .collect()


### PR DESCRIPTION
In the block harness, we need to ensure that all enabled features have corresponding accounts in the accounts db.

Corresponding FD PR: https://github.com/firedancer-io/firedancer/pull/9600