### PR TITLE
compile instruction accounts via `mock_compile_message`

### DIFF
--- a/src/instr.rs
+++ b/src/instr.rs
@@ -10,6 +10,7 @@ use solana_compute_budget::compute_budget::SVMTransactionExecutionCost;
 use solana_hash::Hash;
 use solana_instruction::error::InstructionError;
 use solana_instruction::AccountMeta;
+use solana_instruction::Instruction;
 use solana_precompile_error::PrecompileError;
 use solana_program_runtime::invoke_context::EnvironmentConfig;
 use solana_program_runtime::invoke_context::InvokeContext;
@@ -23,7 +24,6 @@ use solana_runtime::rent_collector::RentCollector;
 use solana_sdk_ids::{
     bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, compute_budget, loader_v4,
 };
-use solana_stable_layout::stable_instruction::StableInstruction;
 use solana_stable_layout::stable_vec::StableVec;
 use solana_svm::program_loader;
 use solana_svm::transaction_processing_callback::TransactionProcessingCallback;
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn sol_compat_instr_execute_v1(
 pub struct InstrContext {
     pub feature_set: FeatureSet,
     pub accounts: Vec<(Pubkey, Account)>,
-    pub instruction: StableInstruction,
+    pub instruction: Instruction,
     pub cu_avail: u64,
     pub rent_collector: RentCollector,
     pub last_blockhash: Hash,
@@ -206,10 +206,10 @@ impl From<protos::InstrContext> for InstrContext {
             );
         }
 
-        let instruction = StableInstruction {
-            accounts: instruction_accounts.into(),
-            data: input.data.into(),
+        let instruction = Instruction {
             program_id,
+            accounts: instruction_accounts,
+            data: input.data,
         };
 
         Self {

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -560,7 +560,7 @@ pub fn execute_instr(input: protos::InstrContext) -> Option<protos::InstrEffects
 
     invoke_context
         .prepare_top_level_instructions(&sanitized_message)
-        .ok()?;
+        .unwrap();
 
     let result = if invoke_context.is_precompile(&program_id) {
         invoke_context.process_precompile(

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -370,22 +370,20 @@ pub(crate) fn create_invoke_context_fields(
     #[allow(deprecated)]
     let recent_blockhashes = sysvar_cache.get_recent_blockhashes().unwrap();
 
-    if !input
+    // Locate the program account, appending a default one if the fixture didn't
+    // supply it. Either way the index is valid, so no fallible lookup is needed.
+    let program_index = input
         .accounts
         .iter()
-        .any(|(pubkey, _)| pubkey == &input.instruction.program_id)
-    {
-        input.accounts.push((
-            input.instruction.program_id,
-            AccountSharedData::default().into(),
-        ));
-    }
-
-    let (_, program_account) = input
-        .accounts
-        .iter_mut()
-        .find(|(pubkey, _)| *pubkey == input.instruction.program_id)
-        .expect("program account present in accounts");
+        .position(|(pubkey, _)| *pubkey == input.instruction.program_id)
+        .unwrap_or_else(|| {
+            input.accounts.push((
+                input.instruction.program_id,
+                AccountSharedData::default().into(),
+            ));
+            input.accounts.len() - 1
+        });
+    let program_account = &mut input.accounts[program_index].1;
 
     // Fixtures provide the program account as a builtin (owned by native loader),
     // but the program-runtime expects the owner to match the cache entry. Since the

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -39,6 +39,7 @@ use protosol::protos;
 use solfuzz_agave_macro::{
     declare_core_bpf_default_compute_units, load_bpf_program, load_core_bpf_program,
 };
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -677,12 +678,17 @@ pub fn execute_instr(input: protos::InstrContext) -> Option<protos::InstrEffects
         err
     });
 
-    let mut modified_accounts: Vec<(Pubkey, Account)> = transaction_context
+    let mut executed: HashMap<Pubkey, AccountSharedData> = transaction_context
         .deconstruct_without_keys()
         .unwrap()
         .into_iter()
         .zip(account_keys)
-        .map(|(account, key)| {
+        .map(|(account, key)| (key, account))
+        .collect();
+
+    let mut modified_accounts: Vec<(Pubkey, Account)> = std::mem::take(&mut input.accounts)
+        .into_iter()
+        .map(|(pubkey, input_account)| {
             #[cfg(any(feature = "core-bpf", feature = "core-bpf-conformance"))]
             // Fixtures provide the program account as a builtin account
             // (owned by native loader).
@@ -692,13 +698,11 @@ pub fn execute_instr(input: protos::InstrContext) -> Option<protos::InstrEffects
             //
             // We need to swap back in the original here to avoid a
             // mismatch.
-            if let Some(program_account) = accounts_snapshot
-                .iter()
-                .find(|(pubkey, _)| *pubkey == program_id)
-            {
-                return (program_account.0, program_account.1.clone());
+            if pubkey == program_id {
+                return (pubkey, input_account);
             }
-            (key, account.into())
+            let account = executed.remove(&pubkey).map(Account::from).unwrap_or(input_account);
+            (pubkey, account)
         })
         .collect();
 

--- a/src/instr.rs
+++ b/src/instr.rs
@@ -11,7 +11,9 @@ use solana_hash::Hash;
 use solana_instruction::error::InstructionError;
 use solana_instruction::AccountMeta;
 use solana_instruction::Instruction;
+use solana_message::SanitizedMessage;
 use solana_precompile_error::PrecompileError;
+use solana_program_runtime::invoke_context::mock_compile_message;
 use solana_program_runtime::invoke_context::EnvironmentConfig;
 use solana_program_runtime::invoke_context::InvokeContext;
 use solana_program_runtime::loaded_programs::ProgramCacheForTxBatch;
@@ -24,16 +26,12 @@ use solana_runtime::rent_collector::RentCollector;
 use solana_sdk_ids::{
     bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, compute_budget, loader_v4,
 };
-use solana_stable_layout::stable_vec::StableVec;
 use solana_svm::program_loader;
 use solana_svm::transaction_processing_callback::TransactionProcessingCallback;
 use solana_svm_callback::InvokeContextCallback;
 use solana_svm_timings::ExecuteTimings;
 use solana_transaction_context::MAX_INSTRUCTION_DATA_LEN;
-use solana_transaction_context::{
-    instruction_accounts::InstructionAccount, transaction::TransactionContext,
-    transaction_accounts::KeyedAccountSharedData, IndexOfAccount,
-};
+use solana_transaction_context::transaction::TransactionContext;
 
 use crate::utils::err_map::instr_err_to_num;
 use crate::utils::feature_set_from_protos;
@@ -224,26 +222,6 @@ impl From<protos::InstrContext> for InstrContext {
     }
 }
 
-pub fn get_instr_accounts(
-    txn_context: &TransactionContext,
-    acct_metas: &StableVec<AccountMeta>,
-) -> Vec<InstructionAccount> {
-    let mut instruction_accounts: Vec<InstructionAccount> =
-        Vec::with_capacity(acct_metas.len().try_into().unwrap());
-    for account_meta in acct_metas.iter() {
-        let index_in_transaction = txn_context
-            .find_index_of_account(&account_meta.pubkey)
-            .expect("invariant violation: account not found in transaction context")
-            as IndexOfAccount;
-        instruction_accounts.push(InstructionAccount::new(
-            index_in_transaction,
-            account_meta.is_signer,
-            account_meta.is_writable,
-        ));
-    }
-    instruction_accounts
-}
-
 fn initialize_program_cache(cache: &mut ProgramCacheForTxBatch, feature_set: &FeatureSet) {
     // Load builtin programs into the cache.
     cache.replenish(
@@ -321,6 +299,7 @@ pub(crate) fn create_invoke_context_fields(
     input: &mut InstrContext,
     populate_program_cache: bool,
 ) -> Option<(
+    SanitizedMessage,
     TransactionContext<'_>,
     SysvarCache,
     ProgramCacheForTxBatch,
@@ -402,39 +381,37 @@ pub(crate) fn create_invoke_context_fields(
         ));
     }
 
-    let mut transaction_accounts =
-        Vec::<KeyedAccountSharedData>::with_capacity(input.accounts.len());
-    #[allow(deprecated)]
-    input
+    let (_, program_account) = input
         .accounts
-        .iter()
-        .map(|(pubkey, account)| {
-            #[cfg(any(
-                feature = "bpf-program-conformance",
-                feature = "core-bpf",
-                feature = "core-bpf-conformance",
-            ))]
-            // Fixtures provide the program account as a builtin (owned by
-            // native loader), but the program-runtime will expect the account
-            // owner to match the cache entry.
-            //
-            // Since we loaded the provided ELF into the cache under loader v3,
-            // stub out the program account here.
-            //
-            // Note: Agave does this during transaction account loading.
-            // https://github.com/anza-xyz/agave/blob/6d74d13749829d463fabccebd8203edf0cf4c500/svm/src/account_loader.rs#L246-L249
-            if *pubkey == input.instruction.program_id {
-                let mut stubbed_out_program_account: AccountSharedData = account.clone().into();
-                stubbed_out_program_account.set_owner(bpf_loader_upgradeable::id());
-                stubbed_out_program_account.set_executable(true);
-                return (*pubkey, stubbed_out_program_account);
-            }
-            (*pubkey, AccountSharedData::from(account.clone()))
-        })
-        .for_each(|x| transaction_accounts.push(x));
+        .iter_mut()
+        .find(|(pubkey, _)| *pubkey == input.instruction.program_id)
+        .expect("program account present in accounts");
+
+    // Fixtures provide the program account as a builtin (owned by native loader),
+    // but the program-runtime expects the owner to match the cache entry. Since the
+    // ELF was loaded into the cache under loader v3, stub the program account here.
+    #[cfg(any(
+        feature = "bpf-program-conformance",
+        feature = "core-bpf",
+        feature = "core-bpf-conformance",
+    ))]
+    {
+        program_account.owner = bpf_loader_upgradeable::id();
+        program_account.executable = true;
+    }
+
+    let loader_key = program_account.owner;
+    let Some((sanitized_message, transaction_accounts)) = mock_compile_message(
+        &input.instruction,
+        &input.accounts,
+        &input.instruction.program_id,
+        &loader_key,
+    ) else {
+        return None;
+    };
 
     let transaction_context = TransactionContext::new(
-        transaction_accounts.clone(),
+        transaction_accounts,
         (*rent).clone(),
         compute_budget.max_instruction_stack_depth,
         compute_budget.max_instruction_trace_length,
@@ -527,6 +504,7 @@ pub(crate) fn create_invoke_context_fields(
     }
 
     Some((
+        sanitized_message,
         transaction_context,
         sysvar_cache,
         program_cache_for_tx_batch,
@@ -545,16 +523,10 @@ pub fn execute_instr(input: protos::InstrContext) -> Option<protos::InstrEffects
     let instruction_data = input.instruction.data.to_vec();
     let runtime_features = input.feature_set.runtime_features();
     let feature_set_snapshot = input.feature_set.clone();
-    let instruction_accounts_snapshot: StableVec<AccountMeta> = input
-        .instruction
-        .accounts
-        .iter()
-        .cloned()
-        .collect::<Vec<_>>()
-        .into();
     let initial_cu_avail = input.cu_avail;
 
     let (
+        sanitized_message,
         mut transaction_context,
         sysvar_cache,
         mut program_cache_for_tx_batch,
@@ -563,10 +535,6 @@ pub fn execute_instr(input: protos::InstrContext) -> Option<protos::InstrEffects
         compute_budget,
         environments,
     ) = create_invoke_context_fields(&mut input, true)?;
-
-    // Get accounts immediately after mutable borrow is released, before creating EnvironmentConfig
-    let instruction_accounts =
-        get_instr_accounts(&transaction_context, &instruction_accounts_snapshot);
 
     let callback_context = SnapshotInvokeContext::new(feature_set_snapshot);
 
@@ -581,8 +549,6 @@ pub fn execute_instr(input: protos::InstrContext) -> Option<protos::InstrEffects
         &sysvar_cache,
     );
 
-    let program_idx = transaction_context.find_index_of_account(&program_id)?;
-
     let mut compute_units_consumed = 0u64;
 
     let mut invoke_context = InvokeContext::new(
@@ -595,13 +561,8 @@ pub fn execute_instr(input: protos::InstrContext) -> Option<protos::InstrEffects
     );
 
     invoke_context
-        .transaction_context
-        .configure_top_level_instruction_for_tests(
-            program_idx,
-            instruction_accounts,
-            instruction_data.clone(),
-        )
-        .unwrap();
+        .prepare_top_level_instructions(&sanitized_message)
+        .ok()?;
 
     let result = if invoke_context.is_precompile(&program_id) {
         invoke_context.process_precompile(

--- a/src/vm_serialization.rs
+++ b/src/vm_serialization.rs
@@ -2,11 +2,9 @@ use crate::instr::{InstrContext, SnapshotInvokeContext};
 use prost::Message;
 use protosol::protos;
 use solana_compute_budget::compute_budget::SVMTransactionExecutionCost;
-use solana_instruction::AccountMeta;
 use solana_program_runtime::invoke_context::EnvironmentConfig;
 use solana_program_runtime::invoke_context::InvokeContext;
 use solana_program_runtime::serialization::serialize_parameters;
-use solana_stable_layout::stable_vec::StableVec;
 use std::ffi::c_int;
 
 #[unsafe(no_mangle)]
@@ -36,19 +34,11 @@ pub unsafe extern "C" fn sol_compat_vm_serialize_execute_v1(
 pub fn execute_vm_serialize(input: protos::InstrContext) -> protos::VmSerializationEffects {
     let mut instr_ctx: InstrContext = input.into();
 
-    let program_id = instr_ctx.instruction.program_id;
-    let instruction_data = instr_ctx.instruction.data.to_vec();
     let runtime_features = instr_ctx.feature_set.runtime_features();
     let feature_set_snapshot = instr_ctx.feature_set.clone();
-    let instruction_accounts_snapshot: StableVec<AccountMeta> = instr_ctx
-        .instruction
-        .accounts
-        .iter()
-        .cloned()
-        .collect::<Vec<_>>()
-        .into();
 
     let (
+        sanitized_message,
         mut transaction_context,
         sysvar_cache,
         mut program_cache_for_tx_batch,
@@ -57,9 +47,6 @@ pub fn execute_vm_serialize(input: protos::InstrContext) -> protos::VmSerializat
         compute_budget,
         environments,
     ) = crate::instr::create_invoke_context_fields(&mut instr_ctx, false).unwrap();
-
-    let instruction_accounts =
-        crate::instr::get_instr_accounts(&transaction_context, &instruction_accounts_snapshot);
 
     let callback_context = SnapshotInvokeContext::new(feature_set_snapshot);
 
@@ -72,10 +59,6 @@ pub fn execute_vm_serialize(input: protos::InstrContext) -> protos::VmSerializat
         &environments,
         &sysvar_cache,
     );
-
-    let program_idx = transaction_context
-        .find_index_of_account(&program_id)
-        .unwrap();
 
     let mut invoke_context = InvokeContext::new(
         &mut transaction_context,
@@ -95,12 +78,7 @@ pub fn execute_vm_serialize(input: protos::InstrContext) -> protos::VmSerializat
         .direct_account_pointers_in_program_input;
 
     invoke_context
-        .transaction_context
-        .configure_top_level_instruction_for_tests(
-            program_idx,
-            instruction_accounts,
-            instruction_data,
-        )
+        .prepare_top_level_instructions(&sanitized_message)
         .unwrap();
 
     invoke_context.push().unwrap();

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -172,7 +172,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         .direct_account_pointers_in_program_input;
     invoke_ctx
         .prepare_top_level_instructions(sanitized_message)
-        .ok()?;
+        .unwrap();
 
     match invoke_ctx.push() {
         Ok(_) => (),

--- a/src/vm_syscalls.rs
+++ b/src/vm_syscalls.rs
@@ -8,7 +8,7 @@ use crate::{
 use prost::Message;
 use protosol::protos::{SyscallContext, SyscallEffects};
 use solana_compute_budget::compute_budget::SVMTransactionExecutionCost;
-use solana_instruction::AccountMeta;
+use solana_message::SanitizedMessage;
 use solana_program_runtime::invoke_context::EnvironmentConfig;
 use solana_program_runtime::memory_context::MemoryContext;
 use solana_program_runtime::serialization::serialize_parameters;
@@ -27,7 +27,6 @@ use solana_sbpf::{
     program::{BuiltinProgram, SBPFVersion},
     vm::{ContextObject, EbpfVm},
 };
-use solana_stable_layout::stable_vec::StableVec;
 use solana_svm_feature_set::SVMFeatureSet;
 use solana_transaction_context::transaction::TransactionContext;
 use std::ffi::c_int;
@@ -67,8 +66,11 @@ fn cleanup_static_ptrs(
     instr_ctx_ptr: usize,
     callback_context_ptr: usize,
     environments_ptr: usize,
+    sanitized_message_ptr: usize,
 ) {
     unsafe {
+        let _sanitized_message_droppable =
+            Box::from_raw(sanitized_message_ptr as *mut SanitizedMessage);
         let _transaction_context_droppable =
             Box::from_raw(transaction_context_ptr as *mut TransactionContext);
         let _sysvar_cache_droppable = Box::from_raw(sysvar_cache_ptr as *mut SysvarCache);
@@ -90,17 +92,6 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     let runtime_feature_set = instr_ctx.feature_set.runtime_features();
     let feature_set_snapshot = instr_ctx.feature_set.clone();
 
-    // Extract values before moving/leaking
-    let program_id = instr_ctx.instruction.program_id;
-    let instruction_data = instr_ctx.instruction.data.to_vec();
-    let instruction_accounts_snapshot: StableVec<AccountMeta> = instr_ctx
-        .instruction
-        .accounts
-        .iter()
-        .cloned()
-        .collect::<Vec<_>>()
-        .into();
-
     /* Optimization: only populate program cache for CPI syscalls */
     let populate_program_cache = input
         .syscall_invocation
@@ -115,6 +106,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
     let instr_ctx_ptr = instr_ctx as *mut InstrContext as usize;
 
     let (
+        sanitized_message,
         transaction_context,
         sysvar_cache,
         program_cache_for_tx_batch,
@@ -123,6 +115,8 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         compute_budget,
         environments,
     ) = crate::instr::create_invoke_context_fields(instr_ctx, populate_program_cache)?;
+    let sanitized_message = Box::leak(Box::new(sanitized_message));
+    let sanitized_message_ptr = sanitized_message as *mut SanitizedMessage as usize;
 
     /* MemoryCowCallback requires moved objects to have the 'static lifetime
       so we promote them to 'static and drop at the end as we are sure they are not used anymore
@@ -145,9 +139,6 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
                 .unwrap();
         }
     }
-
-    let instr_accounts =
-        crate::instr::get_instr_accounts(transaction_context, &instruction_accounts_snapshot);
 
     let environments = Box::leak(Box::new(environments));
     let environments_ptr = environments as *mut _ as usize;
@@ -172,14 +163,6 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         SVMTransactionExecutionCost::default(),
     );
 
-    let program_idx = invoke_ctx
-        .transaction_context
-        .find_index_of_account(&program_id)
-        .expect("invariant violation: program_id must be found in accounts");
-    assert!(
-        program_idx <= 255,
-        "invariant violation: program_idx must be <= 255"
-    );
     let direct_mapping = invoke_ctx.get_feature_set().account_data_direct_mapping;
     let virtual_address_space_adjustments = invoke_ctx
         .get_feature_set()
@@ -188,9 +171,8 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         .get_feature_set()
         .direct_account_pointers_in_program_input;
     invoke_ctx
-        .transaction_context
-        .configure_top_level_instruction_for_tests(program_idx, instr_accounts, instruction_data)
-        .unwrap();
+        .prepare_top_level_instructions(sanitized_message)
+        .ok()?;
 
     match invoke_ctx.push() {
         Ok(_) => (),
@@ -203,6 +185,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
                 instr_ctx_ptr,
                 callback_context_ptr,
                 environments_ptr,
+                sanitized_message_ptr,
             );
             return None;
         }
@@ -261,6 +244,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
             instr_ctx_ptr,
             callback_context_ptr,
             environments_ptr,
+            sanitized_message_ptr,
         );
         return None;
     };
@@ -304,6 +288,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
             instr_ctx_ptr,
             callback_context_ptr,
             environments_ptr,
+            sanitized_message_ptr,
         );
         return None;
     };
@@ -378,6 +363,7 @@ pub fn execute_vm_syscall(input: SyscallContext) -> Option<SyscallEffects> {
         instr_ctx_ptr,
         callback_context_ptr,
         environments_ptr,
+        sanitized_message_ptr,
     );
 
     Some(SyscallEffects {


### PR DESCRIPTION
In Agave, **top-level** instruction accounts are queried from the compiled transaction `Message`, which compiles its account keys [here (as `CompiledKeys`)](https://github.com/anza-xyz/solana-sdk/blob/9e7a1da3f703896d9fdb28ba87713defec2d230d/message/src/compiled_keys.rs#L59-L83). When a message doesn't properly compile its account keys, duplicate entries are caught by Bank [through this check](https://github.com/anza-xyz/agave/blob/b8fa9c075ed5cbd0859edd4fe69a92b328c4e0ef/accounts-db/src/account_locks.rs#L160-L171). You can see this [being tested here](https://github.com/anza-xyz/agave/blob/b8fa9c075ed5cbd0859edd4fe69a92b328c4e0ef/runtime/src/bank/tests.rs#L5005-L5015).

This means that a sanitized message in SVM's message processor is guaranteed to have no duplicate account keys. Due to the protocol-enforced layout of a Solana `Message`, **no two instruction accounts sharing the same index can have different roles** (writable/signer). This is because a `Message` uses an account key's index in its `account_keys` list to query its role. See [`is_signer`](https://github.com/anza-xyz/solana-sdk/blob/01c070e956c80a788156a6389b8ce2c164330569/message/src/legacy.rs#L575-L577) and [`is_writable`](https://github.com/anza-xyz/solana-sdk/blob/01c070e956c80a788156a6389b8ce2c164330569/message/src/sanitized.rs#L71) in the SDK.

In CPI, we don't have a `Message` layout to enforce uniqueness, but we know the transaction accounts have already been deduped (above). So, the program-runtime will merge a CPI instruction's instruction accounts to the highest role manually via [`prepare_next_cpi_instruction`](https://github.com/anza-xyz/agave/blob/2a165e7a90af75c76426d1e031ed0284211d5d1e/program-runtime/src/invoke_context.rs#L314).

SolFuzz-Agave incorrectly builds the list of instruction accounts because it does not merge instruction accounts to their highest role. Instead, it assigns them whatever role was specified in the `AccountMeta`, meaning two accounts sharing the same index can have two different roles.

https://github.com/firedancer-io/solfuzz-agave/blob/4cb2fbc1db70c2bfa8ca86d36fa036fd922ba701/src/instr.rs#L233-L242

This PR patches this discrepancy and rectifies all input instruction accounts to resemble a valid message by actually using a real `Message` via [`mock_compile_message`](https://github.com/anza-xyz/agave/blob/33f3d4ba49fe236334f45fd98bdbfc92761514f4/program-runtime/src/invoke_context.rs#L914), a DCOU function from `solana-program-runtime`.

The issue is: this will break 100% of the instruction fixtures and all CPI syscall fixtures, since the syscall harness shares the same invoke context setup.